### PR TITLE
man: update error message in man page example

### DIFF
--- a/man/InitDeviceTcti.3.in
+++ b/man/InitDeviceTcti.3.in
@@ -143,7 +143,7 @@ TCTI_DEVICE_CONF conf = {
 
 rc = InitDeviceTcti (NULL, &size, NULL);
 if (rc != TSS2_RC_SUCCESS) {
-    fprintf (stderr, "Failed to get allocation size for tabrmd TCTI "
+    fprintf (stderr, "Failed to get allocation size for device TCTI "
              " context: 0x%" PRIx32 "\n", rc);
     exit (EXIT_FAILURE);
 }
@@ -155,7 +155,7 @@ if (tcti_context == NULL) {
 }
 rc = InitDeviceTcti (&tcti_context, &size, &conf);
 if (rc != TSS2_RC_SUCCESS) {
-    fprintf (stderr, "Failed to initialize tabrmd TCTI context: "
+    fprintf (stderr, "Failed to initialize device TCTI context: "
              "0x%" PRIx32 "\n", rc);
     free (tcti_context);
     exit (EXIT_FAILURE);

--- a/man/InitSocketTcti.3.in
+++ b/man/InitSocketTcti.3.in
@@ -178,7 +178,7 @@ TCTI_SOCKET_CONF conf = {
 
 rc = InitSocketTcti (NULL, &size, NULL, 0);
 if (rc != TSS2_RC_SUCCESS) {
-    fprintf (stderr, "Failed to get allocation size for tabrmd TCTI "
+    fprintf (stderr, "Failed to get allocation size for socket TCTI "
              " context: 0x%" PRIx32 "\n", rc);
     exit (EXIT_FAILURE);
 }
@@ -190,7 +190,7 @@ if (tcti_context == NULL) {
 }
 rc = InitSocketTcti (&tcti_context, &size, &conf, 0);
 if (rc != TSS2_RC_SUCCESS) {
-    fprintf (stderr, "Failed to initialize tabrmd TCTI context: "
+    fprintf (stderr, "Failed to initialize socket TCTI context: "
              "0x%" PRIx32 "\n", rc);
     free (tcti_context);
     exit (EXIT_FAILURE);


### PR DESCRIPTION
The man page example implied that these functions connected using the
tabrmd but these are to bypass the tabrmd and go directly to the device
or the socket.

Signed-off-by: Doug Goldstein <cardoe@cardoe.com>