### PR TITLE
Support all algs and commands

### DIFF
--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -39,13 +39,8 @@
 #undef FALSE
 
 // From TPM 2.0 Part 2: Table 4 - Defines for Logic Values
-
-#define  TRUE     1
-#define  FALSE    0
 #define  YES      1
 #define  NO       0
-#define  SET      1
-#define  CLEAR    0
 
 // From Vendor-Specific: Table 1 - Defines for Processor Values
 

--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -38,9 +38,6 @@
 #undef TRUE
 #undef FALSE
 
-#define      CC_YES       YES
-#define      CC_NO        NO
-
 // From TPM 2.0 Part 2: Table 4 - Defines for Logic Values
 
 #define  TRUE     1
@@ -96,118 +93,6 @@
 #define  ECC_KEY_SIZE_BITS_384
 #define  MAX_ECC_KEY_BITS      384
 #define  MAX_ECC_KEY_BYTES     48
-
-// From Vendor-Specific: Table 6 - Defines for Implemented Commands
-
-#define  CC_ActivateCredential            CC_YES
-#define  CC_Certify                       CC_YES
-#define  CC_CertifyCreation               CC_YES
-#define  CC_ChangeEPS                     CC_YES
-#define  CC_ChangePPS                     CC_YES
-#define  CC_Clear                         CC_YES
-#define  CC_ClearControl                  CC_YES
-#define  CC_ClockRateAdjust               CC_YES
-#define  CC_ClockSet                      CC_YES
-#define  CC_Commit                        CC_YES
-#define  CC_ContextLoad                   CC_YES
-#define  CC_ContextSave                   CC_YES
-#define  CC_Create                        CC_YES
-#define  CC_CreatePrimary                 CC_YES
-#define  CC_DictionaryAttackLockReset     CC_YES
-#define  CC_DictionaryAttackParameters    CC_YES
-#define  CC_Duplicate                     CC_YES
-#define  CC_ECC_Parameters                CC_YES
-#define  CC_ECDH_KeyGen                   CC_YES
-#define  CC_ECDH_ZGen                     CC_YES
-#define  CC_EncryptDecrypt                CC_YES
-#define  CC_EventSequenceComplete         CC_YES
-#define  CC_EvictControl                  CC_YES
-#define  CC_FieldUpgradeData              CC_YES
-#define  CC_FieldUpgradeStart             CC_YES
-#define  CC_FirmwareRead                  CC_YES
-#define  CC_FlushContext                  CC_YES
-#define  CC_GetCapability                 CC_YES
-#define  CC_GetCommandAuditDigest         CC_YES
-#define  CC_GetRandom                     CC_YES
-#define  CC_GetSessionAuditDigest         CC_YES
-#define  CC_GetTestResult                 CC_YES
-#define  CC_GetTime                       CC_YES
-#define  CC_Hash                          CC_YES
-#define  CC_HashSequenceStart             CC_YES
-#define  CC_HierarchyChangeAuth           CC_YES
-#define  CC_HierarchyControl              CC_YES
-#define  CC_HMAC                          CC_YES
-#define  CC_HMAC_Start                    CC_YES
-#define  CC_Import                        CC_YES
-#define  CC_IncrementalSelfTest           CC_YES
-#define  CC_Load                          CC_YES
-#define  CC_LoadExternal                  CC_YES
-#define  CC_MakeCredential                CC_YES
-#define  CC_NV_Certify                    CC_YES
-#define  CC_NV_ChangeAuth                 CC_YES
-#define  CC_NV_DefineSpace                CC_YES
-#define  CC_NV_Extend                     CC_YES
-#define  CC_NV_GlobalWriteLock            CC_YES
-#define  CC_NV_Increment                  CC_YES
-#define  CC_NV_Read                       CC_YES
-#define  CC_NV_ReadLock                   CC_YES
-#define  CC_NV_ReadPublic                 CC_YES
-#define  CC_NV_SetBits                    CC_YES
-#define  CC_NV_UndefineSpace              CC_YES
-#define  CC_NV_UndefineSpaceSpecial       CC_YES
-#define  CC_NV_Write                      CC_YES
-#define  CC_NV_WriteLock                  CC_YES
-#define  CC_ObjectChangeAuth              CC_YES
-#define  CC_PCR_Allocate                  CC_YES
-#define  CC_PCR_Event                     CC_YES
-#define  CC_PCR_Extend                    CC_YES
-#define  CC_PCR_Read                      CC_YES
-#define  CC_PCR_Reset                     CC_YES
-#define  CC_PCR_SetAuthPolicy             CC_YES
-#define  CC_PCR_SetAuthValue              CC_YES
-#define  CC_PolicyAuthorize               CC_YES
-#define  CC_PolicyAuthValue               CC_YES
-#define  CC_PolicyCommandCode             CC_YES
-#define  CC_PolicyCounterTimer            CC_YES
-#define  CC_PolicyCpHash                  CC_YES
-#define  CC_PolicyDuplicationSelect       CC_YES
-#define  CC_PolicyGetDigest               CC_YES
-#define  CC_PolicyLocality                CC_YES
-#define  CC_PolicyNameHash                CC_YES
-#define  CC_PolicyNV                      CC_YES
-#define  CC_PolicyOR                      CC_YES
-#define  CC_PolicyPassword                CC_YES
-#define  CC_PolicyPCR                     CC_YES
-#define  CC_PolicyPhysicalPresence        CC_YES
-#define  CC_PolicyRestart                 CC_YES
-#define  CC_PolicySecret                  CC_YES
-#define  CC_PolicySigned                  CC_YES
-#define  CC_PolicyTicket                  CC_YES
-#define  CC_PP_Commands                   CC_YES
-#define  CC_Quote                         CC_YES
-#define  CC_ReadClock                     CC_YES
-#define  CC_ReadPublic                    CC_YES
-#define  CC_Rewrap                        CC_YES
-#define  CC_RSA_Decrypt                   CC_YES
-#define  CC_RSA_Encrypt                   CC_YES
-#define  CC_SelfTest                      CC_YES
-#define  CC_SequenceComplete              CC_YES
-#define  CC_SequenceUpdate                CC_YES
-#define  CC_SetAlgorithmSet               CC_YES
-#define  CC_SetCommandCodeAuditStatus     CC_YES
-#define  CC_SetPrimaryPolicy              CC_YES
-#define  CC_Shutdown                      CC_YES
-#define  CC_Sign                          CC_YES
-#define  CC_StartAuthSession              CC_YES
-#define  CC_Startup                       CC_YES
-#define  CC_StirRandom                    CC_YES
-#define  CC_TestParms                     CC_YES
-#define  CC_Unseal                        CC_YES
-#define  CC_VerifySignature               CC_YES
-#define  CC_ZGen_2Phase                   CC_YES
-#define  CC_EC_Ephemeral                  CC_YES
-#define  CC_PolicyNvWritten               CC_YES
-#define  CC_Vendor_TCG_Test               CC_YES
 
 // From Vendor-Specific: Table 7 - Defines for Implementation Values
 
@@ -405,797 +290,117 @@ typedef  UINT16             TPM_ECC_CURVE;
 
 typedef  UINT32             TPM_CC;
 
-#ifndef CC_NV_UndefineSpaceSpecial
-#   define CC_NV_UndefineSpaceSpecial NO
-#endif
-#if CC_NV_UndefineSpaceSpecial == YES
 #define  TPM_CC_NV_UndefineSpaceSpecial       (TPM_CC)(0x0000011f)
-#endif
-
 #define TPM_CC_FIRST TPM_CC_NV_UndefineSpaceSpecial
-
-#ifndef CC_EvictControl
-#   define CC_EvictControl NO
-#endif
-#if CC_EvictControl == YES
 #define  TPM_CC_EvictControl                  (TPM_CC)(0x00000120)
-#endif
-#ifndef CC_HierarchyControl
-#   define CC_HierarchyControl NO
-#endif
-#if CC_HierarchyControl == YES
 #define  TPM_CC_HierarchyControl              (TPM_CC)(0x00000121)
-#endif
-#ifndef CC_NV_UndefineSpace
-#   define CC_NV_UndefineSpace NO
-#endif
-#if CC_NV_UndefineSpace == YES
 #define  TPM_CC_NV_UndefineSpace              (TPM_CC)(0x00000122)
-#endif
-#ifndef CC_ChangeEPS
-#   define CC_ChangeEPS NO
-#endif
-#if CC_ChangeEPS == YES
 #define  TPM_CC_ChangeEPS                     (TPM_CC)(0x00000124)
-#endif
-#ifndef CC_ChangePPS
-#   define CC_ChangePPS NO
-#endif
-#if CC_ChangePPS == YES
 #define  TPM_CC_ChangePPS                     (TPM_CC)(0x00000125)
-#endif
-#ifndef CC_Clear
-#   define CC_Clear NO
-#endif
-#if CC_Clear == YES
 #define  TPM_CC_Clear                         (TPM_CC)(0x00000126)
-#endif
-#ifndef CC_ClearControl
-#   define CC_ClearControl NO
-#endif
-#if CC_ClearControl == YES
 #define  TPM_CC_ClearControl                  (TPM_CC)(0x00000127)
-#endif
-#ifndef CC_ClockSet
-#   define CC_ClockSet NO
-#endif
-#if CC_ClockSet == YES
 #define  TPM_CC_ClockSet                      (TPM_CC)(0x00000128)
-#endif
-#ifndef CC_HierarchyChangeAuth
-#   define CC_HierarchyChangeAuth NO
-#endif
-#if CC_HierarchyChangeAuth == YES
 #define  TPM_CC_HierarchyChangeAuth           (TPM_CC)(0x00000129)
-#endif
-#ifndef CC_NV_DefineSpace
-#   define CC_NV_DefineSpace NO
-#endif
-#if CC_NV_DefineSpace == YES
 #define  TPM_CC_NV_DefineSpace                (TPM_CC)(0x0000012a)
-#endif
-#ifndef CC_PCR_Allocate
-#   define CC_PCR_Allocate NO
-#endif
-#if CC_PCR_Allocate == YES
 #define  TPM_CC_PCR_Allocate                  (TPM_CC)(0x0000012b)
-#endif
-#ifndef CC_PCR_SetAuthPolicy
-#   define CC_PCR_SetAuthPolicy NO
-#endif
-#if CC_PCR_SetAuthPolicy == YES
 #define  TPM_CC_PCR_SetAuthPolicy             (TPM_CC)(0x0000012c)
-#endif
-#ifndef CC_PP_Commands
-#   define CC_PP_Commands NO
-#endif
-#if CC_PP_Commands == YES
 #define  TPM_CC_PP_Commands                   (TPM_CC)(0x0000012d)
-#endif
-#ifndef CC_SetPrimaryPolicy
-#   define CC_SetPrimaryPolicy NO
-#endif
-#if CC_SetPrimaryPolicy == YES
 #define  TPM_CC_SetPrimaryPolicy              (TPM_CC)(0x0000012e)
-#endif
-#ifndef CC_FieldUpgradeStart
-#   define CC_FieldUpgradeStart NO
-#endif
-#if CC_FieldUpgradeStart == YES
 #define  TPM_CC_FieldUpgradeStart             (TPM_CC)(0x0000012f)
-#endif
-#ifndef CC_ClockRateAdjust
-#   define CC_ClockRateAdjust NO
-#endif
-#if CC_ClockRateAdjust == YES
 #define  TPM_CC_ClockRateAdjust               (TPM_CC)(0x00000130)
-#endif
-#ifndef CC_CreatePrimary
-#   define CC_CreatePrimary NO
-#endif
-#if CC_CreatePrimary == YES
 #define  TPM_CC_CreatePrimary                 (TPM_CC)(0x00000131)
-#endif
-#ifndef CC_NV_GlobalWriteLock
-#   define CC_NV_GlobalWriteLock NO
-#endif
-#if CC_NV_GlobalWriteLock == YES
 #define  TPM_CC_NV_GlobalWriteLock            (TPM_CC)(0x00000132)
-#endif
-#ifndef CC_GetCommandAuditDigest
-#   define CC_GetCommandAuditDigest NO
-#endif
-#if CC_GetCommandAuditDigest == YES
 #define  TPM_CC_GetCommandAuditDigest         (TPM_CC)(0x00000133)
-#endif
-#ifndef CC_NV_Increment
-#   define CC_NV_Increment NO
-#endif
-#if CC_NV_Increment == YES
 #define  TPM_CC_NV_Increment                  (TPM_CC)(0x00000134)
-#endif
-#ifndef CC_NV_SetBits
-#   define CC_NV_SetBits NO
-#endif
-#if CC_NV_SetBits == YES
 #define  TPM_CC_NV_SetBits                    (TPM_CC)(0x00000135)
-#endif
-#ifndef CC_NV_Extend
-#   define CC_NV_Extend NO
-#endif
-#if CC_NV_Extend == YES
 #define  TPM_CC_NV_Extend                     (TPM_CC)(0x00000136)
-#endif
-#ifndef CC_NV_Write
-#   define CC_NV_Write NO
-#endif
-#if CC_NV_Write == YES
 #define  TPM_CC_NV_Write                      (TPM_CC)(0x00000137)
-#endif
-#ifndef CC_NV_WriteLock
-#   define CC_NV_WriteLock NO
-#endif
-#if CC_NV_WriteLock == YES
 #define  TPM_CC_NV_WriteLock                  (TPM_CC)(0x00000138)
-#endif
-#ifndef CC_DictionaryAttackLockReset
-#   define CC_DictionaryAttackLockReset NO
-#endif
-#if CC_DictionaryAttackLockReset == YES
 #define  TPM_CC_DictionaryAttackLockReset     (TPM_CC)(0x00000139)
-#endif
-#ifndef CC_DictionaryAttackParameters
-#   define CC_DictionaryAttackParameters NO
-#endif
-#if CC_DictionaryAttackParameters == YES
 #define  TPM_CC_DictionaryAttackParameters    (TPM_CC)(0x0000013a)
-#endif
-#ifndef CC_NV_ChangeAuth
-#   define CC_NV_ChangeAuth NO
-#endif
-#if CC_NV_ChangeAuth == YES
 #define  TPM_CC_NV_ChangeAuth                 (TPM_CC)(0x0000013b)
-#endif
-#ifndef CC_PCR_Event
-#   define CC_PCR_Event NO
-#endif
-#if CC_PCR_Event == YES
 #define  TPM_CC_PCR_Event                     (TPM_CC)(0x0000013c)
-#endif
-#ifndef CC_PCR_Reset
-#   define CC_PCR_Reset NO
-#endif
-#if CC_PCR_Reset == YES
 #define  TPM_CC_PCR_Reset                     (TPM_CC)(0x0000013d)
-#endif
-#ifndef CC_SequenceComplete
-#   define CC_SequenceComplete NO
-#endif
-#if CC_SequenceComplete == YES
 #define  TPM_CC_SequenceComplete              (TPM_CC)(0x0000013e)
-#endif
-#ifndef CC_SetAlgorithmSet
-#   define CC_SetAlgorithmSet NO
-#endif
-#if CC_SetAlgorithmSet == YES
 #define  TPM_CC_SetAlgorithmSet               (TPM_CC)(0x0000013f)
-#endif
-#ifndef CC_SetCommandCodeAuditStatus
-#   define CC_SetCommandCodeAuditStatus NO
-#endif
-#if CC_SetCommandCodeAuditStatus == YES
 #define  TPM_CC_SetCommandCodeAuditStatus     (TPM_CC)(0x00000140)
-#endif
-#ifndef CC_FieldUpgradeData
-#   define CC_FieldUpgradeData NO
-#endif
-#if CC_FieldUpgradeData == YES
 #define  TPM_CC_FieldUpgradeData              (TPM_CC)(0x00000141)
-#endif
-#ifndef CC_IncrementalSelfTest
-#   define CC_IncrementalSelfTest NO
-#endif
-#if CC_IncrementalSelfTest == YES
 #define  TPM_CC_IncrementalSelfTest           (TPM_CC)(0x00000142)
-#endif
-#ifndef CC_SelfTest
-#   define CC_SelfTest NO
-#endif
-#if CC_SelfTest == YES
 #define  TPM_CC_SelfTest                      (TPM_CC)(0x00000143)
-#endif
-#ifndef CC_Startup
-#   define CC_Startup NO
-#endif
-#if CC_Startup == YES
 #define  TPM_CC_Startup                       (TPM_CC)(0x00000144)
-#endif
-#ifndef CC_Shutdown
-#   define CC_Shutdown NO
-#endif
-#if CC_Shutdown == YES
 #define  TPM_CC_Shutdown                      (TPM_CC)(0x00000145)
-#endif
-#ifndef CC_StirRandom
-#   define CC_StirRandom NO
-#endif
-#if CC_StirRandom == YES
 #define  TPM_CC_StirRandom                    (TPM_CC)(0x00000146)
-#endif
-#ifndef CC_ActivateCredential
-#   define CC_ActivateCredential NO
-#endif
-#if CC_ActivateCredential == YES
 #define  TPM_CC_ActivateCredential            (TPM_CC)(0x00000147)
-#endif
-#ifndef CC_Certify
-#   define CC_Certify NO
-#endif
-#if CC_Certify == YES
 #define  TPM_CC_Certify                       (TPM_CC)(0x00000148)
-#endif
-#ifndef CC_PolicyNV
-#   define CC_PolicyNV NO
-#endif
-#if CC_PolicyNV == YES
 #define  TPM_CC_PolicyNV                      (TPM_CC)(0x00000149)
-#endif
-#ifndef CC_CertifyCreation
-#   define CC_CertifyCreation NO
-#endif
-#if CC_CertifyCreation == YES
 #define  TPM_CC_CertifyCreation               (TPM_CC)(0x0000014a)
-#endif
-#ifndef CC_Duplicate
-#   define CC_Duplicate NO
-#endif
-#if CC_Duplicate == YES
 #define  TPM_CC_Duplicate                     (TPM_CC)(0x0000014b)
-#endif
-#ifndef CC_GetTime
-#   define CC_GetTime NO
-#endif
-#if CC_GetTime == YES
 #define  TPM_CC_GetTime                       (TPM_CC)(0x0000014c)
-#endif
-#ifndef CC_GetSessionAuditDigest
-#   define CC_GetSessionAuditDigest NO
-#endif
-#if CC_GetSessionAuditDigest == YES
 #define  TPM_CC_GetSessionAuditDigest         (TPM_CC)(0x0000014d)
-#endif
-#ifndef CC_NV_Read
-#   define CC_NV_Read NO
-#endif
-#if CC_NV_Read == YES
 #define  TPM_CC_NV_Read                       (TPM_CC)(0x0000014e)
-#endif
-#ifndef CC_NV_ReadLock
-#   define CC_NV_ReadLock NO
-#endif
-#if CC_NV_ReadLock == YES
 #define  TPM_CC_NV_ReadLock                   (TPM_CC)(0x0000014f)
-#endif
-#ifndef CC_ObjectChangeAuth
-#   define CC_ObjectChangeAuth NO
-#endif
-#if CC_ObjectChangeAuth == YES
 #define  TPM_CC_ObjectChangeAuth              (TPM_CC)(0x00000150)
-#endif
-#ifndef CC_PolicySecret
-#   define CC_PolicySecret NO
-#endif
-#if CC_PolicySecret == YES
 #define  TPM_CC_PolicySecret                  (TPM_CC)(0x00000151)
-#endif
-#ifndef CC_Rewrap
-#   define CC_Rewrap NO
-#endif
-#if CC_Rewrap == YES
 #define  TPM_CC_Rewrap                        (TPM_CC)(0x00000152)
-#endif
-#ifndef CC_Create
-#   define CC_Create NO
-#endif
-#if CC_Create == YES
 #define  TPM_CC_Create                        (TPM_CC)(0x00000153)
-#endif
-#ifndef CC_ECDH_ZGen
-#   define CC_ECDH_ZGen NO
-#endif
-#if CC_ECDH_ZGen == YES
 #define  TPM_CC_ECDH_ZGen                     (TPM_CC)(0x00000154)
-#endif
-#ifndef CC_HMAC
-#   define CC_HMAC NO
-#endif
-#if CC_HMAC == YES
 #define  TPM_CC_HMAC                          (TPM_CC)(0x00000155)
-#endif
-#ifndef CC_Import
-#   define CC_Import NO
-#endif
-#if CC_Import == YES
 #define  TPM_CC_Import                        (TPM_CC)(0x00000156)
-#endif
-#ifndef CC_Load
-#   define CC_Load NO
-#endif
-#if CC_Load == YES
 #define  TPM_CC_Load                          (TPM_CC)(0x00000157)
-#endif
-#ifndef CC_Quote
-#   define CC_Quote NO
-#endif
-#if CC_Quote == YES
 #define  TPM_CC_Quote                         (TPM_CC)(0x00000158)
-#endif
-#ifndef CC_RSA_Decrypt
-#   define CC_RSA_Decrypt NO
-#endif
-#if CC_RSA_Decrypt == YES
 #define  TPM_CC_RSA_Decrypt                   (TPM_CC)(0x00000159)
-#endif
-#ifndef CC_HMAC_Start
-#   define CC_HMAC_Start NO
-#endif
-#if CC_HMAC_Start == YES
 #define  TPM_CC_HMAC_Start                    (TPM_CC)(0x0000015b)
-#endif
-#ifndef CC_SequenceUpdate
-#   define CC_SequenceUpdate NO
-#endif
-#if CC_SequenceUpdate == YES
 #define  TPM_CC_SequenceUpdate                (TPM_CC)(0x0000015c)
-#endif
-#ifndef CC_Sign
-#   define CC_Sign NO
-#endif
-#if CC_Sign == YES
 #define  TPM_CC_Sign                          (TPM_CC)(0x0000015d)
-#endif
-#ifndef CC_Unseal
-#   define CC_Unseal NO
-#endif
-#if CC_Unseal == YES
 #define  TPM_CC_Unseal                        (TPM_CC)(0x0000015e)
-#endif
-#ifndef CC_PolicySigned
-#   define CC_PolicySigned NO
-#endif
-#if CC_PolicySigned == YES
 #define  TPM_CC_PolicySigned                  (TPM_CC)(0x00000160)
-#endif
-#ifndef CC_ContextLoad
-#   define CC_ContextLoad NO
-#endif
-#if CC_ContextLoad == YES
 #define  TPM_CC_ContextLoad                   (TPM_CC)(0x00000161)
-#endif
-#ifndef CC_ContextSave
-#   define CC_ContextSave NO
-#endif
-#if CC_ContextSave == YES
 #define  TPM_CC_ContextSave                   (TPM_CC)(0x00000162)
-#endif
-#ifndef CC_ECDH_KeyGen
-#   define CC_ECDH_KeyGen NO
-#endif
-#if CC_ECDH_KeyGen == YES
 #define  TPM_CC_ECDH_KeyGen                   (TPM_CC)(0x00000163)
-#endif
-#ifndef CC_EncryptDecrypt
-#   define CC_EncryptDecrypt NO
-#endif
-#if CC_EncryptDecrypt == YES
 #define  TPM_CC_EncryptDecrypt                (TPM_CC)(0x00000164)
-#endif
-#ifndef CC_FlushContext
-#   define CC_FlushContext NO
-#endif
-#if CC_FlushContext == YES
 #define  TPM_CC_FlushContext                  (TPM_CC)(0x00000165)
-#endif
-#ifndef CC_LoadExternal
-#   define CC_LoadExternal NO
-#endif
-#if CC_LoadExternal == YES
 #define  TPM_CC_LoadExternal                  (TPM_CC)(0x00000167)
-#endif
-#ifndef CC_MakeCredential
-#   define CC_MakeCredential NO
-#endif
-#if CC_MakeCredential == YES
 #define  TPM_CC_MakeCredential                (TPM_CC)(0x00000168)
-#endif
-#ifndef CC_NV_ReadPublic
-#   define CC_NV_ReadPublic NO
-#endif
-#if CC_NV_ReadPublic == YES
 #define  TPM_CC_NV_ReadPublic                 (TPM_CC)(0x00000169)
-#endif
-#ifndef CC_PolicyAuthorize
-#   define CC_PolicyAuthorize NO
-#endif
-#if CC_PolicyAuthorize == YES
 #define  TPM_CC_PolicyAuthorize               (TPM_CC)(0x0000016a)
-#endif
-#ifndef CC_PolicyAuthValue
-#   define CC_PolicyAuthValue NO
-#endif
-#if CC_PolicyAuthValue == YES
 #define  TPM_CC_PolicyAuthValue               (TPM_CC)(0x0000016b)
-#endif
-#ifndef CC_PolicyCommandCode
-#   define CC_PolicyCommandCode NO
-#endif
-#if CC_PolicyCommandCode == YES
 #define  TPM_CC_PolicyCommandCode             (TPM_CC)(0x0000016c)
-#endif
-#ifndef CC_PolicyCounterTimer
-#   define CC_PolicyCounterTimer NO
-#endif
-#if CC_PolicyCounterTimer == YES
 #define  TPM_CC_PolicyCounterTimer            (TPM_CC)(0x0000016d)
-#endif
-#ifndef CC_PolicyCpHash
-#   define CC_PolicyCpHash NO
-#endif
-#if CC_PolicyCpHash == YES
 #define  TPM_CC_PolicyCpHash                  (TPM_CC)(0x0000016e)
-#endif
-#ifndef CC_PolicyLocality
-#   define CC_PolicyLocality NO
-#endif
-#if CC_PolicyLocality == YES
 #define  TPM_CC_PolicyLocality                (TPM_CC)(0x0000016f)
-#endif
-#ifndef CC_PolicyNameHash
-#   define CC_PolicyNameHash NO
-#endif
-#if CC_PolicyNameHash == YES
 #define  TPM_CC_PolicyNameHash                (TPM_CC)(0x00000170)
-#endif
-#ifndef CC_PolicyOR
-#   define CC_PolicyOR NO
-#endif
-#if CC_PolicyOR == YES
 #define  TPM_CC_PolicyOR                      (TPM_CC)(0x00000171)
-#endif
-#ifndef CC_PolicyTicket
-#   define CC_PolicyTicket NO
-#endif
-#if CC_PolicyTicket == YES
 #define  TPM_CC_PolicyTicket                  (TPM_CC)(0x00000172)
-#endif
-#ifndef CC_ReadPublic
-#   define CC_ReadPublic NO
-#endif
-#if CC_ReadPublic == YES
 #define  TPM_CC_ReadPublic                    (TPM_CC)(0x00000173)
-#endif
-#ifndef CC_RSA_Encrypt
-#   define CC_RSA_Encrypt NO
-#endif
-#if CC_RSA_Encrypt == YES
 #define  TPM_CC_RSA_Encrypt                   (TPM_CC)(0x00000174)
-#endif
-#ifndef CC_StartAuthSession
-#   define CC_StartAuthSession NO
-#endif
-#if CC_StartAuthSession == YES
 #define  TPM_CC_StartAuthSession              (TPM_CC)(0x00000176)
-#endif
-#ifndef CC_VerifySignature
-#   define CC_VerifySignature NO
-#endif
-#if CC_VerifySignature == YES
 #define  TPM_CC_VerifySignature               (TPM_CC)(0x00000177)
-#endif
-#ifndef CC_ECC_Parameters
-#   define CC_ECC_Parameters NO
-#endif
-#if CC_ECC_Parameters == YES
 #define  TPM_CC_ECC_Parameters                (TPM_CC)(0x00000178)
-#endif
-#ifndef CC_FirmwareRead
-#   define CC_FirmwareRead NO
-#endif
-#if CC_FirmwareRead == YES
 #define  TPM_CC_FirmwareRead                  (TPM_CC)(0x00000179)
-#endif
-#ifndef CC_GetCapability
-#   define CC_GetCapability NO
-#endif
-#if CC_GetCapability == YES
 #define  TPM_CC_GetCapability                 (TPM_CC)(0x0000017a)
-#endif
-#ifndef CC_GetRandom
-#   define CC_GetRandom NO
-#endif
-#if CC_GetRandom == YES
 #define  TPM_CC_GetRandom                     (TPM_CC)(0x0000017b)
-#endif
-#ifndef CC_GetTestResult
-#   define CC_GetTestResult NO
-#endif
-#if CC_GetTestResult == YES
 #define  TPM_CC_GetTestResult                 (TPM_CC)(0x0000017c)
-#endif
-#ifndef CC_Hash
-#   define CC_Hash NO
-#endif
-#if CC_Hash == YES
 #define  TPM_CC_Hash                          (TPM_CC)(0x0000017d)
-#endif
-#ifndef CC_PCR_Read
-#   define CC_PCR_Read NO
-#endif
-#if CC_PCR_Read == YES
 #define  TPM_CC_PCR_Read                      (TPM_CC)(0x0000017e)
-#endif
-#ifndef CC_PolicyPCR
-#   define CC_PolicyPCR NO
-#endif
-#if CC_PolicyPCR == YES
 #define  TPM_CC_PolicyPCR                     (TPM_CC)(0x0000017f)
-#endif
-#ifndef CC_PolicyRestart
-#   define CC_PolicyRestart NO
-#endif
-#if CC_PolicyRestart == YES
 #define  TPM_CC_PolicyRestart                 (TPM_CC)(0x00000180)
-#endif
-#ifndef CC_ReadClock
-#   define CC_ReadClock NO
-#endif
-#if CC_ReadClock == YES
 #define  TPM_CC_ReadClock                     (TPM_CC)(0x00000181)
-#endif
-#ifndef CC_PCR_Extend
-#   define CC_PCR_Extend NO
-#endif
-#if CC_PCR_Extend == YES
 #define  TPM_CC_PCR_Extend                    (TPM_CC)(0x00000182)
-#endif
-#ifndef CC_PCR_SetAuthValue
-#   define CC_PCR_SetAuthValue NO
-#endif
-#if CC_PCR_SetAuthValue == YES
 #define  TPM_CC_PCR_SetAuthValue              (TPM_CC)(0x00000183)
-#endif
-#ifndef CC_NV_Certify
-#   define CC_NV_Certify NO
-#endif
-#if CC_NV_Certify == YES
 #define  TPM_CC_NV_Certify                    (TPM_CC)(0x00000184)
-#endif
-#ifndef CC_EventSequenceComplete
-#   define CC_EventSequenceComplete NO
-#endif
-#if CC_EventSequenceComplete == YES
 #define  TPM_CC_EventSequenceComplete         (TPM_CC)(0x00000185)
-#endif
-#ifndef CC_HashSequenceStart
-#   define CC_HashSequenceStart NO
-#endif
-#if CC_HashSequenceStart == YES
 #define  TPM_CC_HashSequenceStart             (TPM_CC)(0x00000186)
-#endif
-#ifndef CC_PolicyPhysicalPresence
-#   define CC_PolicyPhysicalPresence NO
-#endif
-#if CC_PolicyPhysicalPresence == YES
 #define  TPM_CC_PolicyPhysicalPresence        (TPM_CC)(0x00000187)
-#endif
-#ifndef CC_PolicyDuplicationSelect
-#   define CC_PolicyDuplicationSelect NO
-#endif
-#if CC_PolicyDuplicationSelect == YES
 #define  TPM_CC_PolicyDuplicationSelect       (TPM_CC)(0x00000188)
-#endif
-#ifndef CC_PolicyGetDigest
-#   define CC_PolicyGetDigest NO
-#endif
-#if CC_PolicyGetDigest == YES
 #define  TPM_CC_PolicyGetDigest               (TPM_CC)(0x00000189)
-#endif
-#ifndef CC_TestParms
-#   define CC_TestParms NO
-#endif
-#if CC_TestParms == YES
 #define  TPM_CC_TestParms                     (TPM_CC)(0x0000018a)
-#endif
-#ifndef CC_Commit
-#   define CC_Commit NO
-#endif
-#if CC_Commit == YES
 #define  TPM_CC_Commit                        (TPM_CC)(0x0000018b)
-#endif
-#ifndef CC_PolicyPassword
-#   define CC_PolicyPassword NO
-#endif
-#if CC_PolicyPassword == YES
 #define  TPM_CC_PolicyPassword                (TPM_CC)(0x0000018c)
-#endif
-#ifndef CC_ZGen_2Phase
-#   define CC_ZGen_2Phase NO
-#endif
-#if CC_ZGen_2Phase == YES
 #define  TPM_CC_ZGen_2Phase                   (TPM_CC)(0x0000018d)
-#endif
-#ifndef CC_EC_Ephemeral
-#   define CC_EC_Ephemeral NO
-#endif
-#if CC_EC_Ephemeral == YES
 #define  TPM_CC_EC_Ephemeral                  (TPM_CC)(0x0000018e)
-#endif
-#ifndef CC_PolicyNvWritten
-#   define CC_PolicyNvWritten NO
-#endif
-#if CC_PolicyNvWritten == YES
 #define  TPM_CC_PolicyNvWritten               (TPM_CC)(0x0000018f)
-#endif
 #define  TPM_CC_LAST                          (TPM_CC)(0x0000018f)
-#ifndef CC_Vendor_TCG_Test
-#   define CC_Vendor_TCG_Test NO
-#endif
-#if CC_Vendor_TCG_Test == YES
 #define  TPM_CC_Vendor_TCG_Test               (TPM_CC)(0x20000000)
-#endif
-
-#ifndef  COMPRESSED_LISTS
-#define ADD_FILL    1
-#else
-#define ADD_FILL   0
-#endif
-
-// Size the array of library commands based on whether or not the array is packed (only defined
-// commands) or dense (having entries for unimplemented commands)
-
-#define LIBRARY_COMMAND_ARRAY_SIZE       (0				\
-					  + (ADD_FILL || CC_NV_UndefineSpaceSpecial)    /* 0x0000011f */ \
-					  + (ADD_FILL || CC_EvictControl)               /* 0x00000120 */ \
-					  + (ADD_FILL || CC_HierarchyControl)           /* 0x00000121 */ \
-					  + (ADD_FILL || CC_NV_UndefineSpace)           /* 0x00000122 */ \
-					  + ADD_FILL                                             /* 0x00000123 */ \
-					  + (ADD_FILL || CC_ChangeEPS)                  /* 0x00000124 */ \
-					  + (ADD_FILL || CC_ChangePPS)                  /* 0x00000125 */ \
-					  + (ADD_FILL || CC_Clear)                      /* 0x00000126 */ \
-					  + (ADD_FILL || CC_ClearControl)               /* 0x00000127 */ \
-					  + (ADD_FILL || CC_ClockSet)                   /* 0x00000128 */ \
-					  + (ADD_FILL || CC_HierarchyChangeAuth)        /* 0x00000129 */ \
-					  + (ADD_FILL || CC_NV_DefineSpace)             /* 0x0000012a */ \
-					  + (ADD_FILL || CC_PCR_Allocate)               /* 0x0000012b */ \
-					  + (ADD_FILL || CC_PCR_SetAuthPolicy)          /* 0x0000012c */ \
-					  + (ADD_FILL || CC_PP_Commands)                /* 0x0000012d */ \
-					  + (ADD_FILL || CC_SetPrimaryPolicy)           /* 0x0000012e */ \
-					  + (ADD_FILL || CC_FieldUpgradeStart)          /* 0x0000012f */ \
-					  + (ADD_FILL || CC_ClockRateAdjust)            /* 0x00000130 */ \
-					  + (ADD_FILL || CC_CreatePrimary)              /* 0x00000131 */ \
-					  + (ADD_FILL || CC_NV_GlobalWriteLock)         /* 0x00000132 */ \
-					  + (ADD_FILL || CC_GetCommandAuditDigest)      /* 0x00000133 */ \
-					  + (ADD_FILL || CC_NV_Increment)               /* 0x00000134 */ \
-					  + (ADD_FILL || CC_NV_SetBits)                 /* 0x00000135 */ \
-					  + (ADD_FILL || CC_NV_Extend)                  /* 0x00000136 */ \
-					  + (ADD_FILL || CC_NV_Write)                   /* 0x00000137 */ \
-					  + (ADD_FILL || CC_NV_WriteLock)               /* 0x00000138 */ \
-					  + (ADD_FILL || CC_DictionaryAttackLockReset)  /* 0x00000139 */ \
-					  + (ADD_FILL || CC_DictionaryAttackParameters) /* 0x0000013a */ \
-					  + (ADD_FILL || CC_NV_ChangeAuth)              /* 0x0000013b */ \
-					  + (ADD_FILL || CC_PCR_Event)                  /* 0x0000013c */ \
-					  + (ADD_FILL || CC_PCR_Reset)                  /* 0x0000013d */ \
-					  + (ADD_FILL || CC_SequenceComplete)           /* 0x0000013e */ \
-					  + (ADD_FILL || CC_SetAlgorithmSet)            /* 0x0000013f */ \
-					  + (ADD_FILL || CC_SetCommandCodeAuditStatus)  /* 0x00000140 */ \
-					  + (ADD_FILL || CC_FieldUpgradeData)           /* 0x00000141 */ \
-					  + (ADD_FILL || CC_IncrementalSelfTest)        /* 0x00000142 */ \
-					  + (ADD_FILL || CC_SelfTest)                   /* 0x00000143 */ \
-					  + (ADD_FILL || CC_Startup)                    /* 0x00000144 */ \
-					  + (ADD_FILL || CC_Shutdown)                   /* 0x00000145 */ \
-					  + (ADD_FILL || CC_StirRandom)                 /* 0x00000146 */ \
-					  + (ADD_FILL || CC_ActivateCredential)         /* 0x00000147 */ \
-					  + (ADD_FILL || CC_Certify)                    /* 0x00000148 */ \
-					  + (ADD_FILL || CC_PolicyNV)                   /* 0x00000149 */ \
-					  + (ADD_FILL || CC_CertifyCreation)            /* 0x0000014a */ \
-					  + (ADD_FILL || CC_Duplicate)                  /* 0x0000014b */ \
-					  + (ADD_FILL || CC_GetTime)                    /* 0x0000014c */ \
-					  + (ADD_FILL || CC_GetSessionAuditDigest)      /* 0x0000014d */ \
-					  + (ADD_FILL || CC_NV_Read)                    /* 0x0000014e */ \
-					  + (ADD_FILL || CC_NV_ReadLock)                /* 0x0000014f */ \
-					  + (ADD_FILL || CC_ObjectChangeAuth)           /* 0x00000150 */ \
-					  + (ADD_FILL || CC_PolicySecret)               /* 0x00000151 */ \
-					  + (ADD_FILL || CC_Rewrap)                     /* 0x00000152 */ \
-					  + (ADD_FILL || CC_Create)                     /* 0x00000153 */ \
-					  + (ADD_FILL || CC_ECDH_ZGen)                  /* 0x00000154 */ \
-					  + (ADD_FILL || CC_HMAC)                       /* 0x00000155 */ \
-					  + (ADD_FILL || CC_Import)                     /* 0x00000156 */ \
-					  + (ADD_FILL || CC_Load)                       /* 0x00000157 */ \
-					  + (ADD_FILL || CC_Quote)                      /* 0x00000158 */ \
-					  + (ADD_FILL || CC_RSA_Decrypt)                /* 0x00000159 */ \
-					  + ADD_FILL                                             /* 0x0000015a */ \
-					  + (ADD_FILL || CC_HMAC_Start)                 /* 0x0000015b */ \
-					  + (ADD_FILL || CC_SequenceUpdate)             /* 0x0000015c */ \
-					  + (ADD_FILL || CC_Sign)                       /* 0x0000015d */ \
-					  + (ADD_FILL || CC_Unseal)                     /* 0x0000015e */ \
-					  + ADD_FILL                                             /* 0x0000015f */ \
-					  + (ADD_FILL || CC_PolicySigned)               /* 0x00000160 */ \
-					  + (ADD_FILL || CC_ContextLoad)                /* 0x00000161 */ \
-					  + (ADD_FILL || CC_ContextSave)                /* 0x00000162 */ \
-					  + (ADD_FILL || CC_ECDH_KeyGen)                /* 0x00000163 */ \
-					  + (ADD_FILL || CC_EncryptDecrypt)             /* 0x00000164 */ \
-					  + (ADD_FILL || CC_FlushContext)               /* 0x00000165 */ \
-					  + ADD_FILL                                             /* 0x00000166 */ \
-					  + (ADD_FILL || CC_LoadExternal)               /* 0x00000167 */ \
-					  + (ADD_FILL || CC_MakeCredential)             /* 0x00000168 */ \
-					  + (ADD_FILL || CC_NV_ReadPublic)              /* 0x00000169 */ \
-					  + (ADD_FILL || CC_PolicyAuthorize)            /* 0x0000016a */ \
-					  + (ADD_FILL || CC_PolicyAuthValue)            /* 0x0000016b */ \
-					  + (ADD_FILL || CC_PolicyCommandCode)          /* 0x0000016c */ \
-					  + (ADD_FILL || CC_PolicyCounterTimer)         /* 0x0000016d */ \
-					  + (ADD_FILL || CC_PolicyCpHash)               /* 0x0000016e */ \
-					  + (ADD_FILL || CC_PolicyLocality)             /* 0x0000016f */ \
-					  + (ADD_FILL || CC_PolicyNameHash)             /* 0x00000170 */ \
-					  + (ADD_FILL || CC_PolicyOR)                   /* 0x00000171 */ \
-					  + (ADD_FILL || CC_PolicyTicket)               /* 0x00000172 */ \
-					  + (ADD_FILL || CC_ReadPublic)                 /* 0x00000173 */ \
-					  + (ADD_FILL || CC_RSA_Encrypt)                /* 0x00000174 */ \
-					  + ADD_FILL                                             /* 0x00000175 */ \
-					  + (ADD_FILL || CC_StartAuthSession)           /* 0x00000176 */ \
-					  + (ADD_FILL || CC_VerifySignature)            /* 0x00000177 */ \
-					  + (ADD_FILL || CC_ECC_Parameters)             /* 0x00000178 */ \
-					  + (ADD_FILL || CC_FirmwareRead)               /* 0x00000179 */ \
-					  + (ADD_FILL || CC_GetCapability)              /* 0x0000017a */ \
-					  + (ADD_FILL || CC_GetRandom)                  /* 0x0000017b */ \
-					  + (ADD_FILL || CC_GetTestResult)              /* 0x0000017c */ \
-					  + (ADD_FILL || CC_Hash)                       /* 0x0000017d */ \
-					  + (ADD_FILL || CC_PCR_Read)                   /* 0x0000017e */ \
-					  + (ADD_FILL || CC_PolicyPCR)                  /* 0x0000017f */ \
-					  + (ADD_FILL || CC_PolicyRestart)              /* 0x00000180 */ \
-					  + (ADD_FILL || CC_ReadClock)                  /* 0x00000181 */ \
-					  + (ADD_FILL || CC_PCR_Extend)                 /* 0x00000182 */ \
-					  + (ADD_FILL || CC_PCR_SetAuthValue)           /* 0x00000183 */ \
-					  + (ADD_FILL || CC_NV_Certify)                 /* 0x00000184 */ \
-					  + (ADD_FILL || CC_EventSequenceComplete)      /* 0x00000185 */ \
-					  + (ADD_FILL || CC_HashSequenceStart)          /* 0x00000186 */ \
-					  + (ADD_FILL || CC_PolicyPhysicalPresence)     /* 0x00000187 */ \
-					  + (ADD_FILL || CC_PolicyDuplicationSelect)    /* 0x00000188 */ \
-					  + (ADD_FILL || CC_PolicyGetDigest)            /* 0x00000189 */ \
-					  + (ADD_FILL || CC_TestParms)                  /* 0x0000018a */ \
-					  + (ADD_FILL || CC_Commit)                     /* 0x0000018b */ \
-					  + (ADD_FILL || CC_PolicyPassword)             /* 0x0000018c */ \
-					  + (ADD_FILL || CC_ZGen_2Phase)                /* 0x0000018d */ \
-					  + (ADD_FILL || CC_EC_Ephemeral)               /* 0x0000018e */ \
-					  + (ADD_FILL || CC_PolicyNvWritten)            /* 0x0000018f */ \
-					  )
-
-#define VENDOR_COMMAND_ARRAY_SIZE   ( 0					\
-				      + CC_Vendor_TCG_Test		\
-				      )
-
-#define COMMAND_COUNT							\
-    (LIBRARY_COMMAND_ARRAY_SIZE + VENDOR_COMMAND_ARRAY_SIZE)
-
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -38,9 +38,6 @@
 #undef TRUE
 #undef FALSE
 
-// This table is built in to TpmStructures() Change these definitions to turn all algorithms or commands on or off
-#define      ALG_YES      YES
-#define      ALG_NO       NO
 #define      CC_YES       YES
 #define      CC_NO        NO
 
@@ -58,41 +55,6 @@
 #define BIG_ENDIAN_TPM       	NO	/*  to YES or NO according to the processor */
 #define LITTLE_ENDIAN_TPM	YES	/*  to YES or NO according to the processor */
 #define NO_AUTO_ALIGN		NO	/*  to YES if the processor does not allow unaligned accesses */
-
-// From Vendor-Specific: Table 2 - Defines for Implemented Algorithms
-
-#define  ALG_RSA               ALG_YES
-#define  ALG_SHA1              ALG_YES
-#define  ALG_HMAC              ALG_YES
-#define  ALG_AES               ALG_YES
-#define  ALG_MGF1              ALG_YES
-#define  ALG_XOR               ALG_YES
-#define  ALG_KEYEDHASH         ALG_YES
-#define  ALG_SHA256            ALG_YES
-#define  ALG_SHA384            ALG_YES
-#define  ALG_SHA512            ALG_YES
-#define  ALG_SM3_256           ALG_YES
-#define  ALG_SM4               ALG_YES
-#define  ALG_RSASSA            (ALG_YES*ALG_RSA)
-#define  ALG_RSAES             (ALG_YES*ALG_RSA)
-#define  ALG_RSAPSS            (ALG_YES*ALG_RSA)
-#define  ALG_OAEP              (ALG_YES*ALG_RSA)
-#define  ALG_ECC               ALG_YES
-#define  ALG_ECDH              (ALG_YES*ALG_ECC)
-#define  ALG_ECDSA             (ALG_YES*ALG_ECC)
-#define  ALG_ECDAA             (ALG_YES*ALG_ECC)
-#define  ALG_SM2               (ALG_YES*ALG_ECC)
-#define  ALG_ECSCHNORR         (ALG_YES*ALG_ECC)
-#define  ALG_ECMQV             (ALG_NO*ALG_ECC)
-#define  ALG_SYMCIPHER         ALG_YES
-#define  ALG_KDF1_SP800_56A    (ALG_YES*ALG_ECC)
-#define  ALG_KDF2              ALG_NO
-#define  ALG_KDF1_SP800_108    ALG_YES
-#define  ALG_CTR               ALG_YES
-#define  ALG_OFB               ALG_YES
-#define  ALG_CBC               ALG_YES
-#define  ALG_CFB               ALG_YES
-#define  ALG_ECB               ALG_YES
 
 // From Vendor-Specific: Table 4 - Defines for Key Size Constants
 
@@ -146,7 +108,7 @@
 #define  CC_ClearControl                  CC_YES
 #define  CC_ClockRateAdjust               CC_YES
 #define  CC_ClockSet                      CC_YES
-#define  CC_Commit                        (CC_YES*ALG_ECC)
+#define  CC_Commit                        CC_YES
 #define  CC_ContextLoad                   CC_YES
 #define  CC_ContextSave                   CC_YES
 #define  CC_Create                        CC_YES
@@ -154,9 +116,9 @@
 #define  CC_DictionaryAttackLockReset     CC_YES
 #define  CC_DictionaryAttackParameters    CC_YES
 #define  CC_Duplicate                     CC_YES
-#define  CC_ECC_Parameters                (CC_YES*ALG_ECC)
-#define  CC_ECDH_KeyGen                   (CC_YES*ALG_ECC)
-#define  CC_ECDH_ZGen                     (CC_YES*ALG_ECC)
+#define  CC_ECC_Parameters                CC_YES
+#define  CC_ECDH_KeyGen                   CC_YES
+#define  CC_ECDH_ZGen                     CC_YES
 #define  CC_EncryptDecrypt                CC_YES
 #define  CC_EventSequenceComplete         CC_YES
 #define  CC_EvictControl                  CC_YES
@@ -226,8 +188,8 @@
 #define  CC_ReadClock                     CC_YES
 #define  CC_ReadPublic                    CC_YES
 #define  CC_Rewrap                        CC_YES
-#define  CC_RSA_Decrypt                   (CC_YES*ALG_RSA)
-#define  CC_RSA_Encrypt                   (CC_YES*ALG_RSA)
+#define  CC_RSA_Decrypt                   CC_YES
+#define  CC_RSA_Encrypt                   CC_YES
 #define  CC_SelfTest                      CC_YES
 #define  CC_SequenceComplete              CC_YES
 #define  CC_SequenceUpdate                CC_YES
@@ -242,8 +204,8 @@
 #define  CC_TestParms                     CC_YES
 #define  CC_Unseal                        CC_YES
 #define  CC_VerifySignature               CC_YES
-#define  CC_ZGen_2Phase                   (CC_YES*ALG_ECC)
-#define  CC_EC_Ephemeral                  (CC_YES*ALG_ECC)
+#define  CC_ZGen_2Phase                   CC_YES
+#define  CC_EC_Ephemeral                  CC_YES
 #define  CC_PolicyNvWritten               CC_YES
 #define  CC_Vendor_TCG_Test               CC_YES
 
@@ -322,161 +284,46 @@
 
 typedef  UINT16             TPM_ALG_ID;
 #define  TPM_ALG_ERROR               (TPM_ALG_ID)(0x0000)
-#define  ALG_ERROR_VALUE             0x0000
-#if defined ALG_RSA && ALG_RSA == YES
 #define  TPM_ALG_RSA                 (TPM_ALG_ID)(0x0001)
-#endif
-#define  ALG_RSA_VALUE               0x0001
-#if defined ALG_SHA && ALG_SHA == YES
 #define  TPM_ALG_SHA                 (TPM_ALG_ID)(0x0004)
-#endif
-#define  ALG_SHA_VALUE               0x0004
-#if defined ALG_SHA1 && ALG_SHA1 == YES
 #define  TPM_ALG_SHA1                (TPM_ALG_ID)(0x0004)
-#endif
-#define  ALG_SHA1_VALUE              0x0004
-#if defined ALG_HMAC && ALG_HMAC == YES
 #define  TPM_ALG_HMAC                (TPM_ALG_ID)(0x0005)
-#endif
-#define  ALG_HMAC_VALUE              0x0005
-#if defined ALG_AES && ALG_AES == YES
 #define  TPM_ALG_AES                 (TPM_ALG_ID)(0x0006)
-#endif
-#define  ALG_AES_VALUE               0x0006
-#if defined ALG_MGF1 && ALG_MGF1 == YES
 #define  TPM_ALG_MGF1                (TPM_ALG_ID)(0x0007)
-#endif
-#define  ALG_MGF1_VALUE              0x0007
-#if defined ALG_KEYEDHASH && ALG_KEYEDHASH == YES
 #define  TPM_ALG_KEYEDHASH           (TPM_ALG_ID)(0x0008)
-#endif
-#define  ALG_KEYEDHASH_VALUE         0x0008
-#if defined ALG_XOR && ALG_XOR == YES
 #define  TPM_ALG_XOR                 (TPM_ALG_ID)(0x000A)
-#endif
-#define  ALG_XOR_VALUE               0x000A
-#if defined ALG_SHA256 && ALG_SHA256 == YES
 #define  TPM_ALG_SHA256              (TPM_ALG_ID)(0x000B)
-#endif
-#define  ALG_SHA256_VALUE            0x000B
-#if defined ALG_SHA384 && ALG_SHA384 == YES
 #define  TPM_ALG_SHA384              (TPM_ALG_ID)(0x000C)
-#endif
-#define  ALG_SHA384_VALUE            0x000C
-#if defined ALG_SHA512 && ALG_SHA512 == YES
 #define  TPM_ALG_SHA512              (TPM_ALG_ID)(0x000D)
-#endif
-#define  ALG_SHA512_VALUE            0x000D
 #define  TPM_ALG_NULL                (TPM_ALG_ID)(0x0010)
-#define  ALG_NULL_VALUE              0x0010
-#if defined ALG_SM3_256 && ALG_SM3_256 == YES
 #define  TPM_ALG_SM3_256             (TPM_ALG_ID)(0x0012)
-#endif
-#define  ALG_SM3_256_VALUE           0x0012
-#if defined ALG_SM4 && ALG_SM4 == YES
 #define  TPM_ALG_SM4                 (TPM_ALG_ID)(0x0013)
-#endif
-#define  ALG_SM4_VALUE               0x0013
-#if defined ALG_RSASSA && ALG_RSASSA == YES
 #define  TPM_ALG_RSASSA              (TPM_ALG_ID)(0x0014)
-#endif
-#define  ALG_RSASSA_VALUE            0x0014
-#if defined ALG_RSAES && ALG_RSAES == YES
 #define  TPM_ALG_RSAES               (TPM_ALG_ID)(0x0015)
-#endif
-#define  ALG_RSAES_VALUE             0x0015
-#if defined ALG_RSAPSS && ALG_RSAPSS == YES
 #define  TPM_ALG_RSAPSS              (TPM_ALG_ID)(0x0016)
-#endif
-#define  ALG_RSAPSS_VALUE            0x0016
-#if defined ALG_OAEP && ALG_OAEP == YES
 #define  TPM_ALG_OAEP                (TPM_ALG_ID)(0x0017)
-#endif
-#define  ALG_OAEP_VALUE              0x0017
-#if defined ALG_ECDSA && ALG_ECDSA == YES
 #define  TPM_ALG_ECDSA               (TPM_ALG_ID)(0x0018)
-#endif
-#define  ALG_ECDSA_VALUE             0x0018
-#if defined ALG_ECDH && ALG_ECDH == YES
 #define  TPM_ALG_ECDH                (TPM_ALG_ID)(0x0019)
-#endif
-#define  ALG_ECDH_VALUE              0x0019
-#if defined ALG_ECDAA && ALG_ECDAA == YES
 #define  TPM_ALG_ECDAA               (TPM_ALG_ID)(0x001A)
-#endif
-#define  ALG_ECDAA_VALUE             0x001A
-#if defined ALG_SM2 && ALG_SM2 == YES
 #define  TPM_ALG_SM2                 (TPM_ALG_ID)(0x001B)
-#endif
-#define  ALG_SM2_VALUE               0x001B
-#if defined ALG_ECSCHNORR && ALG_ECSCHNORR == YES
 #define  TPM_ALG_ECSCHNORR           (TPM_ALG_ID)(0x001C)
-#endif
-#define  ALG_ECSCHNORR_VALUE         0x001C
-#if defined ALG_ECMQV && ALG_ECMQV == YES
 #define  TPM_ALG_ECMQV               (TPM_ALG_ID)(0x001D)
-#endif
-#define  ALG_ECMQV_VALUE             0x001D
-#if defined ALG_KDF1_SP800_56A && ALG_KDF1_SP800_56A == YES
 #define  TPM_ALG_KDF1_SP800_56A      (TPM_ALG_ID)(0x0020)
-#endif
-#define  ALG_KDF1_SP800_56A_VALUE    0x0020
-#if defined ALG_KDF2 && ALG_KDF2 == YES
 #define  TPM_ALG_KDF2                (TPM_ALG_ID)(0x0021)
-#endif
-#define  ALG_KDF2_VALUE              0x0021
-#if defined ALG_KDF1_SP800_108 && ALG_KDF1_SP800_108 == YES
 #define  TPM_ALG_KDF1_SP800_108      (TPM_ALG_ID)(0x0022)
-#endif
-#define  ALG_KDF1_SP800_108_VALUE    0x0022
-#if defined ALG_ECC && ALG_ECC == YES
 #define  TPM_ALG_ECC                 (TPM_ALG_ID)(0x0023)
-#endif
-#define  ALG_ECC_VALUE               0x0023
-#if defined ALG_SYMCIPHER && ALG_SYMCIPHER == YES
 #define  TPM_ALG_SYMCIPHER           (TPM_ALG_ID)(0x0025)
-#endif
-#define  ALG_SYMCIPHER_VALUE         0x0025
-#if defined ALG_CAMELLIA && ALG_CAMELLIA == YES
 #define  TPM_ALG_CAMELLIA            (TPM_ALG_ID)(0x0026)
-#endif
-#define  ALG_CAMELLIA_VALUE          0x0026
-#if defined ALG_CTR && ALG_CTR == YES
 #define  TPM_ALG_CTR                 (TPM_ALG_ID)(0x0040)
-#endif
-#if defined ALG_SHA3_256 && ALG_SHA3_256 == YES
 #define TPM_ALG_SHA3_256 (TPM_ALG_ID)0x27
-#endif
-#define ALG_SHA3_256_VALUE 0x27
-#if defined ALG_SHA3_384 && ALG_SHA3_384 == YES
 #define TPM_ALG_SHA3_384 (TPM_ALG_ID)0x28
-#endif
-#define ALG_SHA3_384_VALUE 0x28
-#if defined ALG_SHA3_512 && ALG_SHA3_512 == YES
 #define TPM_ALG_SHA3_512 (TPM_ALG_ID)0x29
-#endif
-#define ALG_SHA3_512_VALUE 0x29
-#define  ALG_CTR_VALUE               0x0040
-#if defined ALG_OFB && ALG_OFB == YES
 #define  TPM_ALG_OFB                 (TPM_ALG_ID)(0x0041)
-#endif
-#define  ALG_OFB_VALUE               0x0041
-#if defined ALG_CBC && ALG_CBC == YES
 #define  TPM_ALG_CBC                 (TPM_ALG_ID)(0x0042)
-#endif
-#define  ALG_CBC_VALUE               0x0042
-#if defined ALG_CFB && ALG_CFB == YES
 #define  TPM_ALG_CFB                 (TPM_ALG_ID)(0x0043)
-#endif
-#define  ALG_CFB_VALUE               0x0043
-#if defined ALG_ECB && ALG_ECB == YES
 #define  TPM_ALG_ECB                 (TPM_ALG_ID)(0x0044)
-#endif
-#define  ALG_ECB_VALUE               0x0044
 #define  TPM_ALG_FIRST               (TPM_ALG_ID)(0x0001)
-#define  ALG_FIRST_VALUE             0x0001
 #define  TPM_ALG_LAST                (TPM_ALG_ID)(0x0044)
-#define  ALG_LAST_VALUE              0x0044
 //     From TCG Algorithm Registry: Table 3 - Definition of TPM_ECC_CURVE Constants
 
 typedef  UINT16             TPM_ECC_CURVE;
@@ -1355,74 +1202,43 @@ typedef  UINT32             TPM_CC;
 #endif
 
 #define MAX_HASH_BLOCK_SIZE  (						\
-			      MAX(ALG_SHA1 * SHA1_BLOCK_SIZE,		\
-				  MAX(ALG_SHA256 * SHA256_BLOCK_SIZE,	\
-				      MAX(ALG_SHA384 * SHA384_BLOCK_SIZE, \
-					  MAX(ALG_SM3_256 * SM3_256_BLOCK_SIZE, \
-					      MAX(ALG_SHA512 * SHA512_BLOCK_SIZE, \
+			      MAX(SHA1_BLOCK_SIZE,		\
+				  MAX(SHA256_BLOCK_SIZE,	\
+				      MAX(SHA384_BLOCK_SIZE, \
+					  MAX(SM3_256_BLOCK_SIZE, \
+					      MAX(SHA512_BLOCK_SIZE, \
 						  0 ))))))
 
 #define MAX_DIGEST_SIZE      (						\
-			      MAX(ALG_SHA1 * SHA1_DIGEST_SIZE,		\
-				  MAX(ALG_SHA256 * SHA256_DIGEST_SIZE,	\
-				      MAX(ALG_SHA384 * SHA384_DIGEST_SIZE, \
-					  MAX(ALG_SM3_256 * SM3_256_DIGEST_SIZE, \
-					      MAX(ALG_SHA512 * SHA512_DIGEST_SIZE, \
+			      MAX(SHA1_DIGEST_SIZE,		\
+				  MAX(SHA256_DIGEST_SIZE,	\
+				      MAX(SHA384_DIGEST_SIZE, \
+					  MAX(SM3_256_DIGEST_SIZE, \
+					      MAX(SHA512_DIGEST_SIZE, \
 						  0 ))))))
 
 #if MAX_DIGEST_SIZE == 0 || MAX_HASH_BLOCK_SIZE == 0
 #error "Hash data not valid"
 #endif
 
-#define HASH_COUNT (ALG_SHA1+ALG_SHA256+ALG_SHA384+ALG_SM3_256+ALG_SHA512)
+#define HASH_COUNT 5
 
 TPM2B_TYPE(MAX_HASH_BLOCK, MAX_HASH_BLOCK_SIZE);
-
-// Following typedef is for some old code
-
-typedef TPM2B_MAX_HASH_BLOCK    TPM2B_HASH_BLOCK;
 
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
-#ifndef ALG_CAMELLIA
-#   define ALG_CAMELLIA         NO
-#endif
-
-#ifndef MAX_CAMELLIA_KEY_BITS
-#   define      MAX_CAMELLIA_KEY_BITS  0
-#   define      MAX_CAMELLIA_BLOCK_SIZE_BYTES 0
-#endif
-
-#ifndef ALG_SM4
-#   define ALG_SM4         NO
-#endif
-
-#ifndef MAX_SM4_KEY_BITS
-#   define      MAX_SM4_KEY_BITS  0
-#   define      MAX_SM4_BLOCK_SIZE_BYTES 0
-#endif
-
-#ifndef ALG_AES
-#   define ALG_AES         NO
-#endif
-
-#ifndef MAX_AES_KEY_BITS
-#   define      MAX_AES_KEY_BITS  0
-#   define      MAX_AES_BLOCK_SIZE_BYTES 0
-#endif
-
 #define MAX_SYM_KEY_BITS (						\
-			  MAX(MAX_CAMELLIA_KEY_BITS * ALG_CAMELLIA,	\
-			      MAX(MAX_SM4_KEY_BITS * ALG_SM4,		\
-				  MAX(MAX_AES_KEY_BITS * ALG_AES,	\
+			  MAX(MAX_CAMELLIA_KEY_BITS,	\
+			      MAX(MAX_SM4_KEY_BITS,		\
+				  MAX(MAX_AES_KEY_BITS,	\
 				      0))))
 #define MAX_SYM_KEY_BYTES ((MAX_SYM_KEY_BITS + 7) / 8)
 #define MAX_SYM_BLOCK_SIZE  (						\
-			     MAX(MAX_CAMELLIA_BLOCK_SIZE_BYTES * ALG_CAMELLIA, \
-				 MAX(MAX_SM4_BLOCK_SIZE_BYTES * ALG_SM4, \
-				     MAX(MAX_AES_BLOCK_SIZE_BYTES * ALG_AES, \
+			     MAX(MAX_CAMELLIA_BLOCK_SIZE_BYTES, \
+				 MAX(MAX_SM4_BLOCK_SIZE_BYTES, \
+				     MAX(MAX_AES_BLOCK_SIZE_BYTES, \
 					 0))))
 #if MAX_SYM_KEY_BITS == 0 || MAX_SYM_BLOCK_SIZE == 0
 #   error Bad size for MAX_SYM_KEY_BITS or MAX_SYM_BLOCK_SIZE

--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -43,7 +43,7 @@
 #define    MAX_CAP_DATA         (MAX_CAP_BUFFER-sizeof(TPM_CAP)-sizeof(UINT32))
 #define    MAX_CAP_ALGS         (TPM_ALG_LAST - TPM_ALG_FIRST + 1)
 #define    MAX_CAP_HANDLES      (MAX_CAP_DATA/sizeof(TPM_HANDLE))
-#define    MAX_CAP_CC           (COMMAND_COUNT)
+#define    MAX_CAP_CC           256
 #define    MAX_TPM_PROPERTIES   (MAX_CAP_DATA/sizeof(TPMS_TAGGED_PROPERTY))
 #define    MAX_PCR_PROPERTIES   (MAX_CAP_DATA/sizeof(TPMS_TAGGED_PCR_SELECT))
 #define    MAX_ECC_CURVES       (MAX_CAP_DATA/sizeof(TPM_ECC_CURVE))

--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -37,9 +37,6 @@
 
 #include "implementation.h"
 
-#define SET	1
-#define CLEAR	0
-
 #define    MAX_CAP_DATA         (MAX_CAP_BUFFER-sizeof(TPM_CAP)-sizeof(UINT32))
 #define    MAX_CAP_ALGS         (TPM_ALG_LAST - TPM_ALG_FIRST + 1)
 #define    MAX_CAP_HANDLES      (MAX_CAP_DATA/sizeof(TPM_HANDLE))
@@ -47,14 +44,6 @@
 #define    MAX_TPM_PROPERTIES   (MAX_CAP_DATA/sizeof(TPMS_TAGGED_PROPERTY))
 #define    MAX_PCR_PROPERTIES   (MAX_CAP_DATA/sizeof(TPMS_TAGGED_PCR_SELECT))
 #define    MAX_ECC_CURVES       (MAX_CAP_DATA/sizeof(TPM_ECC_CURVE))
-
-/* Table 4  Defines for Logic Values */
-#define	TRUE	1
-#define	FALSE	0
-#define	YES	1
-#define	NO	0
-#define	SET	1
-#define	CLEAR	0
 
 /* Table 5  Definition of Types for Documentation Clarity */
 typedef	UINT32	TPM_ALGORITHM_ID;	 /* this is the 1.2 compatible form of the TPM_ALG_ID  */

--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -41,7 +41,7 @@
 #define CLEAR	0
 
 #define    MAX_CAP_DATA         (MAX_CAP_BUFFER-sizeof(TPM_CAP)-sizeof(UINT32))
-#define    MAX_CAP_ALGS         (ALG_LAST_VALUE - ALG_FIRST_VALUE + 1)
+#define    MAX_CAP_ALGS         (TPM_ALG_LAST - TPM_ALG_FIRST + 1)
 #define    MAX_CAP_HANDLES      (MAX_CAP_DATA/sizeof(TPM_HANDLE))
 #define    MAX_CAP_CC           (COMMAND_COUNT)
 #define    MAX_TPM_PROPERTIES   (MAX_CAP_DATA/sizeof(TPMS_TAGGED_PROPERTY))
@@ -987,24 +987,11 @@ typedef	struct {
 
 /* Table 70  Definition of TPMU_HA Union <INOUT S> */
 typedef	union {
-#ifdef TPM_ALG_SHA
-	BYTE	sha[SHA_DIGEST_SIZE];	 /* all hashes  */
-#endif
-#ifdef TPM_ALG_SHA1
 	BYTE	sha1[SHA1_DIGEST_SIZE];	 /* all hashes  */
-#endif
-#ifdef TPM_ALG_SHA256
 	BYTE	sha256[SHA256_DIGEST_SIZE];	 /* all hashes  */
-#endif
-#ifdef TPM_ALG_SHA384
 	BYTE	sha384[SHA384_DIGEST_SIZE];	 /* all hashes  */
-#endif
-#ifdef TPM_ALG_SHA512
 	BYTE	sha512[SHA512_DIGEST_SIZE];	 /* all hashes  */
-#endif
-#ifdef TPM_ALG_SM3_256
 	BYTE	sm3_256[SM3_256_DIGEST_SIZE];	 /* all hashes  */
-#endif
 } TPMU_HA;
 
 /* Table 71  Definition of TPMT_HA Structure <INOUT> */
@@ -1313,30 +1300,18 @@ typedef	TPM_KEY_BITS TPMI_CAMELLIA_KEY_BITS;
 
 /* Table 125  Definition of TPMU_SYM_KEY_BITS Union */
 typedef	union {
-#ifdef TPM_ALG_AES
 	TPMI_AES_KEY_BITS	aes;	 /* all symmetric algorithms  */
-#endif
-#ifdef TPM_ALG_SM4
 	TPMI_SM4_KEY_BITS	sm4;	 /* all symmetric algorithms  */
-#endif
-#ifdef TPM_ALG_CAMELLIA
 	TPMI_CAMELLIA_KEY_BITS	camellia;	 /* all symmetric algorithms  */
-#endif
 	TPM_KEY_BITS	sym;	 /* when selector may be any of the symmetric block ciphers  */
 	TPMI_ALG_HASH	exclusiveOr;	 /* overload for using xorNOTE	TPM_ALG_NULL is not allowed  */
 } TPMU_SYM_KEY_BITS;
 
 /* Table 126  Definition of TPMU_SYM_MODE Union */
 typedef	union {
-#ifdef TPM_ALG_AES
 	TPMI_ALG_SYM_MODE	aes;	 /*   */
-#endif
-#ifdef TPM_ALG_SM4
 	TPMI_ALG_SYM_MODE	sm4;	 /*   */
-#endif
-#ifdef TPM_ALG_CAMELLIA
 	TPMI_ALG_SYM_MODE	camellia;	 /*   */
-#endif
 	TPMI_ALG_SYM_MODE	sym;	 /* when selector may be any of the symmetric block ciphers  */
 } TPMU_SYM_MODE;
 
@@ -1421,24 +1396,12 @@ typedef	TPMS_SCHEME_ECDAA	TPMS_SIG_SCHEME_ECDAA;	 /* schemes that need a hash an
 
 /* Table 144  Definition of TPMU_SIG_SCHEME Union <INOUT S> */
 typedef	union {
-#ifdef TPM_ALG_RSASSA
 	TPMS_SIG_SCHEME_RSASSA	rsassa;	 /* all signing schemes including anonymous schemes  */
-#endif
-#ifdef TPM_ALG_RSAPSS
 	TPMS_SIG_SCHEME_RSAPSS	rsapss;	 /* all signing schemes including anonymous schemes  */
-#endif
-#ifdef TPM_ALG_ECDSA
 	TPMS_SIG_SCHEME_ECDSA	ecdsa;	 /* all signing schemes including anonymous schemes  */
-#endif
-#ifdef TPM_ALG_ECDAA
 	TPMS_SIG_SCHEME_ECDAA	ecdaa;	 /* all signing schemes including anonymous schemes  */
-#endif
-#ifdef TPM_ALG_SM2
 	TPMS_SIG_SCHEME_SM2	sm2;	 /* all signing schemes including anonymous schemes  */
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	TPMS_SIG_SCHEME_ECSCHNORR	ecschnorr;	 /* all signing schemes including anonymous schemes  */
-#endif
 	TPMS_SCHEME_HMAC	hmac;	 /* the HMAC scheme  */
 	TPMS_SCHEME_HASH	any;	 /* selector that allows access to digest for any signing scheme  */
 } TPMU_SIG_SCHEME;
@@ -1465,18 +1428,10 @@ typedef	TPMS_SCHEME_HASH	TPMS_SCHEME_KDF1_SP800_108;	 /* hashbased key or maskge
 
 /* Table 149  Definition of TPMU_KDF_SCHEME Union <INOUT S> */
 typedef	union {
-#ifdef TPM_ALG_MGF1
 	TPMS_SCHEME_MGF1	mgf1;	 /*   */
-#endif
-#ifdef TPM_ALG_KDF1_SP800_56A
 	TPMS_SCHEME_KDF1_SP800_56A	kdf1_sp800_56a;	 /*   */
-#endif
-#ifdef TPM_ALG_KDF2
 	TPMS_SCHEME_KDF2	kdf2;	 /*   */
-#endif
-#ifdef TPM_ALG_KDF1_SP800_108
 	TPMS_SCHEME_KDF1_SP800_108	kdf1_sp800_108;	 /*   */
-#endif
 } TPMU_KDF_SCHEME;
 
 /* Table 150  Definition of TPMT_KDF_SCHEME Structure */
@@ -1490,36 +1445,16 @@ typedef	TPM_ALG_ID TPMI_ALG_ASYM_SCHEME;
 
 /* Table 152  Definition of TPMU_ASYM_SCHEME Union */
 typedef	union {
-#ifdef TPM_ALG_ECDH
 	TPMS_KEY_SCHEME_ECDH	ecdh;	 /*   */
-#endif
-#ifdef TPM_ALG_ECMQV
 	TPMS_KEY_SCHEME_ECMQV	ecmqv;	 /*   */
-#endif
-#ifdef TPM_ALG_RSASSA
 	TPMS_SIG_SCHEME_RSASSA	rsassa;	 /* signing and anonymous signing  */
-#endif
-#ifdef TPM_ALG_RSAPSS
 	TPMS_SIG_SCHEME_RSAPSS	rsapss;	 /* signing and anonymous signing  */
-#endif
-#ifdef TPM_ALG_ECDSA
 	TPMS_SIG_SCHEME_ECDSA	ecdsa;	 /* signing and anonymous signing  */
-#endif
-#ifdef TPM_ALG_ECDAA
 	TPMS_SIG_SCHEME_ECDAA	ecdaa;	 /* signing and anonymous signing  */
-#endif
-#ifdef TPM_ALG_SM2
 	TPMS_SIG_SCHEME_SM2	sm2;	 /* signing and anonymous signing  */
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	TPMS_SIG_SCHEME_ECSCHNORR	ecschnorr;	 /* signing and anonymous signing  */
-#endif
-#ifdef TPM_ALG_RSAES
 	TPMS_ENC_SCHEME_RSAES	rsaes;	 /* schemes with no hash  */
-#endif
-#ifdef TPM_ALG_OAEP
 	TPMS_ENC_SCHEME_OAEP	oaep;	 /* schemes with no hash  */
-#endif
 	TPMS_SCHEME_HASH	anySig;	 /*   */
 } TPMU_ASYM_SCHEME;
 
@@ -1620,24 +1555,12 @@ typedef	TPMS_SIGNATURE_ECC	TPMS_SIGNATURE_ECSCHNORR;	 /*   */
 
 /* Table 172  Definition of TPMU_SIGNATURE Union <INOUT S> */
 typedef	union {
-#ifdef TPM_ALG_RSASSA
 	TPMS_SIGNATURE_RSASSA	rsassa;	 /* all asymmetric signatures  */
-#endif
-#ifdef TPM_ALG_RSAPSS
 	TPMS_SIGNATURE_RSAPSS	rsapss;	 /* all asymmetric signatures  */
-#endif
-#ifdef TPM_ALG_ECDSA
 	TPMS_SIGNATURE_ECDSA	ecdsa;	 /* all asymmetric signatures  */
-#endif
-#ifdef TPM_ALG_ECDAA
 	TPMS_SIGNATURE_ECDAA	ecdaa;	 /* all asymmetric signatures  */
-#endif
-#ifdef TPM_ALG_SM2
 	TPMS_SIGNATURE_SM2	sm2;	 /* all asymmetric signatures  */
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	TPMS_SIGNATURE_ECSCHNORR	ecschnorr;	 /* all asymmetric signatures  */
-#endif
 	TPMT_HA	hmac;	 /* HMAC signature required to be supported  */
 	TPMS_SCHEME_HASH	any;	 /* used to access the hash  */
 } TPMU_SIGNATURE;

--- a/sysapi/sysapi_util/GetDigestSize.c
+++ b/sysapi/sysapi_util/GetDigestSize.c
@@ -37,12 +37,8 @@ typedef struct {
 HASH_SIZE_INFO   hashSizes[] = {
     {TPM_ALG_SHA1,          SHA1_DIGEST_SIZE},
     {TPM_ALG_SHA256,        SHA256_DIGEST_SIZE},
-#ifdef TPM_ALG_SHA384
     {TPM_ALG_SHA384,        SHA384_DIGEST_SIZE},
-#endif
-#ifdef TPM_ALG_SHA512
     {TPM_ALG_SHA512,        SHA512_DIGEST_SIZE},
-#endif
     {TPM_ALG_SM3_256,       SM3_256_DIGEST_SIZE},
     {TPM_ALG_NULL,0}
 };

--- a/sysapi/sysapi_util/Marshal_TPMU_ASYM_SCHEME.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_ASYM_SCHEME.c
@@ -39,60 +39,38 @@ void Marshal_TPMU_ASYM_SCHEME(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_ECDH
 	case TPM_ALG_ECDH:
 			Marshal_TPMS_KEY_SCHEME_ECDH( sysContext, &asymScheme->ecdh );
 			break;
-#endif
-#ifdef TPM_ALG_ECMQV
 	case TPM_ALG_ECMQV:
 			Marshal_TPMS_KEY_SCHEME_ECMQV( sysContext, &asymScheme->ecmqv );
 			break;
-#endif
-#ifdef TPM_ALG_RSASSA
 	case TPM_ALG_RSASSA:
 			Marshal_TPMS_SIG_SCHEME_RSASSA( sysContext, &asymScheme->rsassa );
 			break;
-#endif
-#ifdef TPM_ALG_RSAPSS
 	case TPM_ALG_RSAPSS:
 			Marshal_TPMS_SIG_SCHEME_RSAPSS( sysContext, &asymScheme->rsapss );
 			break;
-#endif
-#ifdef TPM_ALG_ECDSA
 	case TPM_ALG_ECDSA:
 			Marshal_TPMS_SIG_SCHEME_ECDSA( sysContext, &asymScheme->ecdsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECDAA
 	case TPM_ALG_ECDAA:
 			Marshal_TPMS_SIG_SCHEME_ECDAA( sysContext, &asymScheme->ecdaa );
 			break;
-#endif
-#ifdef TPM_ALG_SM2
 	case TPM_ALG_SM2:
 			Marshal_TPMS_SIG_SCHEME_SM2( sysContext, &asymScheme->sm2 );
 			break;
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	case TPM_ALG_ECSCHNORR:
 			Marshal_TPMS_SIG_SCHEME_ECSCHNORR( sysContext, &asymScheme->ecschnorr );
 			break;
-#endif
-#ifdef TPM_ALG_RSAES
 	case TPM_ALG_RSAES:
 			Marshal_TPMS_ENC_SCHEME_RSAES( sysContext, &asymScheme->rsaes );
 			break;
-#endif
-#ifdef TPM_ALG_OAEP
 	case TPM_ALG_OAEP:
 			Marshal_TPMS_ENC_SCHEME_OAEP( sysContext, &asymScheme->oaep );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_HA.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_HA.c
@@ -41,16 +41,6 @@ void Marshal_TPMU_HA(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_SHA
-	case TPM_ALG_SHA:
-
-	for( i = 0; i < SHA_DIGEST_SIZE; i++ )
-	{
-		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha[i], &( SYS_CONTEXT->rval ) );
-	}
-			break;
-#endif
-#ifdef TPM_ALG_SHA1
 	case TPM_ALG_SHA1:
 
 	for( i = 0; i < SHA1_DIGEST_SIZE; i++ )
@@ -58,8 +48,6 @@ void Marshal_TPMU_HA(
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha1[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SHA256
 	case TPM_ALG_SHA256:
 
 	for( i = 0; i < SHA256_DIGEST_SIZE; i++ )
@@ -67,8 +55,6 @@ void Marshal_TPMU_HA(
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha256[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SHA384
 	case TPM_ALG_SHA384:
 
 	for( i = 0; i < SHA384_DIGEST_SIZE; i++ )
@@ -76,8 +62,6 @@ void Marshal_TPMU_HA(
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha384[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SHA512
 	case TPM_ALG_SHA512:
 
 	for( i = 0; i < SHA512_DIGEST_SIZE; i++ )
@@ -85,8 +69,6 @@ void Marshal_TPMU_HA(
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha512[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SM3_256
 	case TPM_ALG_SM3_256:
 
 	for( i = 0; i < SM3_256_DIGEST_SIZE; i++ )
@@ -94,11 +76,8 @@ void Marshal_TPMU_HA(
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sm3_256[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_KDF_SCHEME.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_KDF_SCHEME.c
@@ -39,30 +39,20 @@ void Marshal_TPMU_KDF_SCHEME(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_MGF1
 	case TPM_ALG_MGF1:
 			Marshal_TPMS_SCHEME_MGF1( sysContext, &kdfScheme->mgf1 );
 			break;
-#endif
-#ifdef TPM_ALG_KDF1_SP800_56A
 	case TPM_ALG_KDF1_SP800_56A:
 			Marshal_TPMS_SCHEME_KDF1_SP800_56A( sysContext, &kdfScheme->kdf1_sp800_56a );
 			break;
-#endif
-#ifdef TPM_ALG_KDF2
 	case TPM_ALG_KDF2:
 			Marshal_TPMS_SCHEME_KDF2( sysContext, &kdfScheme->kdf2 );
 			break;
-#endif
-#ifdef TPM_ALG_KDF1_SP800_108
 	case TPM_ALG_KDF1_SP800_108:
 			Marshal_TPMS_SCHEME_KDF1_SP800_108( sysContext, &kdfScheme->kdf1_sp800_108 );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_PUBLIC_ID.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_PUBLIC_ID.c
@@ -39,26 +39,18 @@ void Marshal_TPMU_PUBLIC_ID(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_KEYEDHASH
 	case TPM_ALG_KEYEDHASH:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&publicVarId->keyedHash );
 			break;
-#endif
-#ifdef TPM_ALG_SYMCIPHER
 	case TPM_ALG_SYMCIPHER:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&publicVarId->sym );
 			break;
-#endif
-#ifdef TPM_ALG_RSA
 	case TPM_ALG_RSA:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&publicVarId->rsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECC
 	case TPM_ALG_ECC:
 			Marshal_TPMS_ECC_POINT( sysContext, &publicVarId->ecc );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_PUBLIC_PARMS.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_PUBLIC_PARMS.c
@@ -39,26 +39,18 @@ void Marshal_TPMU_PUBLIC_PARMS(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_KEYEDHASH
 	case TPM_ALG_KEYEDHASH:
 			Marshal_TPMS_KEYEDHASH_PARMS( sysContext, &publicVarParms->keyedHashDetail );
 			break;
-#endif
-#ifdef TPM_ALG_SYMCIPHER
 	case TPM_ALG_SYMCIPHER:
 			Marshal_TPMS_SYMCIPHER_PARMS( sysContext, &publicVarParms->symDetail );
 			break;
-#endif
-#ifdef TPM_ALG_RSA
 	case TPM_ALG_RSA:
 			Marshal_TPMS_RSA_PARMS( sysContext, &publicVarParms->rsaDetail );
 			break;
-#endif
-#ifdef TPM_ALG_ECC
 	case TPM_ALG_ECC:
 			Marshal_TPMS_ECC_PARMS( sysContext, &publicVarParms->eccDetail );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_SCHEME_KEYEDHASH.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_SCHEME_KEYEDHASH.c
@@ -39,20 +39,14 @@ void Marshal_TPMU_SCHEME_KEYEDHASH(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_HMAC
 	case TPM_ALG_HMAC:
 			Marshal_TPMS_SCHEME_HMAC( sysContext, &schemeKeyedhash->hmac );
 			break;
-#endif
-#ifdef TPM_ALG_XOR
 	case TPM_ALG_XOR:
 			Marshal_TPMS_SCHEME_XOR( sysContext, &schemeKeyedhash->exclusiveOr );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_SENSITIVE_COMPOSITE.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_SENSITIVE_COMPOSITE.c
@@ -39,26 +39,18 @@ void Marshal_TPMU_SENSITIVE_COMPOSITE(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_RSA
 	case TPM_ALG_RSA:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&sensitiveComposite->rsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECC
 	case TPM_ALG_ECC:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&sensitiveComposite->ecc );
 			break;
-#endif
-#ifdef TPM_ALG_KEYEDHASH
 	case TPM_ALG_KEYEDHASH:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&sensitiveComposite->bits );
 			break;
-#endif
-#ifdef TPM_ALG_SYMCIPHER
 	case TPM_ALG_SYMCIPHER:
 			MARSHAL_SIMPLE_TPM2B( sysContext, (TPM2B *)&sensitiveComposite->sym );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_SIGNATURE.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_SIGNATURE.c
@@ -39,45 +39,29 @@ void Marshal_TPMU_SIGNATURE(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_RSASSA
 	case TPM_ALG_RSASSA:
 			Marshal_TPMS_SIGNATURE_RSASSA( sysContext, &signature->rsassa );
 			break;
-#endif
-#ifdef TPM_ALG_RSAPSS
 	case TPM_ALG_RSAPSS:
 			Marshal_TPMS_SIGNATURE_RSAPSS( sysContext, &signature->rsapss );
 			break;
-#endif
-#ifdef TPM_ALG_ECDSA
 	case TPM_ALG_ECDSA:
 			Marshal_TPMS_SIGNATURE_ECDSA( sysContext, &signature->ecdsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECDAA
 	case TPM_ALG_ECDAA:
 			Marshal_TPMS_SIGNATURE_ECDAA( sysContext, &signature->ecdaa );
 			break;
-#endif
-#ifdef TPM_ALG_SM2
 	case TPM_ALG_SM2:
 			Marshal_TPMS_SIGNATURE_SM2( sysContext, &signature->sm2 );
 			break;
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	case TPM_ALG_ECSCHNORR:
 			Marshal_TPMS_SIGNATURE_ECSCHNORR( sysContext, &signature->ecschnorr );
 			break;
-#endif
-#ifdef TPM_ALG_HMAC
 	case TPM_ALG_HMAC:
 			Marshal_TPMT_HA( sysContext, &signature->hmac );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_SIG_SCHEME.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_SIG_SCHEME.c
@@ -39,45 +39,29 @@ void Marshal_TPMU_SIG_SCHEME(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_RSASSA
 	case TPM_ALG_RSASSA:
 			Marshal_TPMS_SIG_SCHEME_RSASSA( sysContext, &sigScheme->rsassa );
 			break;
-#endif
-#ifdef TPM_ALG_RSAPSS
 	case TPM_ALG_RSAPSS:
 			Marshal_TPMS_SIG_SCHEME_RSAPSS( sysContext, &sigScheme->rsapss );
 			break;
-#endif
-#ifdef TPM_ALG_ECDSA
 	case TPM_ALG_ECDSA:
 			Marshal_TPMS_SIG_SCHEME_ECDSA( sysContext, &sigScheme->ecdsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECDAA
 	case TPM_ALG_ECDAA:
 			Marshal_TPMS_SIG_SCHEME_ECDAA( sysContext, &sigScheme->ecdaa );
 			break;
-#endif
-#ifdef TPM_ALG_SM2
 	case TPM_ALG_SM2:
 			Marshal_TPMS_SIG_SCHEME_SM2( sysContext, &sigScheme->sm2 );
 			break;
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	case TPM_ALG_ECSCHNORR:
 			Marshal_TPMS_SIG_SCHEME_ECSCHNORR( sysContext, &sigScheme->ecschnorr );
 			break;
-#endif
-#ifdef TPM_ALG_HMAC
 	case TPM_ALG_HMAC:
 			Marshal_TPMS_SCHEME_HMAC( sysContext, &sigScheme->hmac );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_SYM_KEY_BITS.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_SYM_KEY_BITS.c
@@ -39,30 +39,20 @@ void Marshal_TPMU_SYM_KEY_BITS(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_AES
 	case TPM_ALG_AES:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symKeyBits->aes, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_SM4
 	case TPM_ALG_SM4:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symKeyBits->sm4, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_CAMELLIA
 	case TPM_ALG_CAMELLIA:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symKeyBits->camellia, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_XOR
 	case TPM_ALG_XOR:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symKeyBits->exclusiveOr, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Marshal_TPMU_SYM_MODE.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_SYM_MODE.c
@@ -39,29 +39,19 @@ void Marshal_TPMU_SYM_MODE(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_AES
 	case TPM_ALG_AES:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symMode->aes, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_SM4
 	case TPM_ALG_SM4:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symMode->sm4, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_CAMELLIA
 	case TPM_ALG_CAMELLIA:
 			Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), symMode->camellia, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_XOR
 	case TPM_ALG_XOR:
 					break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_ASYM_SCHEME.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_ASYM_SCHEME.c
@@ -42,60 +42,38 @@ void Unmarshal_TPMU_ASYM_SCHEME(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_ECDH
 	case TPM_ALG_ECDH:
 			Unmarshal_TPMS_KEY_SCHEME_ECDH( sysContext, &asymScheme->ecdh );
 			break;
-#endif
-#ifdef TPM_ALG_ECMQV
 	case TPM_ALG_ECMQV:
 			Unmarshal_TPMS_KEY_SCHEME_ECMQV( sysContext, &asymScheme->ecmqv );
 			break;
-#endif
-#ifdef TPM_ALG_RSASSA
 	case TPM_ALG_RSASSA:
 			Unmarshal_TPMS_SIG_SCHEME_RSASSA( sysContext, &asymScheme->rsassa );
 			break;
-#endif
-#ifdef TPM_ALG_RSAPSS
 	case TPM_ALG_RSAPSS:
 			Unmarshal_TPMS_SIG_SCHEME_RSAPSS( sysContext, &asymScheme->rsapss );
 			break;
-#endif
-#ifdef TPM_ALG_ECDSA
 	case TPM_ALG_ECDSA:
 			Unmarshal_TPMS_SIG_SCHEME_ECDSA( sysContext, &asymScheme->ecdsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECDAA
 	case TPM_ALG_ECDAA:
 			Unmarshal_TPMS_SIG_SCHEME_ECDAA( sysContext, &asymScheme->ecdaa );
 			break;
-#endif
-#ifdef TPM_ALG_SM2
 	case TPM_ALG_SM2:
 			Unmarshal_TPMS_SIG_SCHEME_SM2( sysContext, &asymScheme->sm2 );
 			break;
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	case TPM_ALG_ECSCHNORR:
 			Unmarshal_TPMS_SIG_SCHEME_ECSCHNORR( sysContext, &asymScheme->ecschnorr );
 			break;
-#endif
-#ifdef TPM_ALG_RSAES
 	case TPM_ALG_RSAES:
 			Unmarshal_TPMS_ENC_SCHEME_RSAES( sysContext, &asymScheme->rsaes );
 			break;
-#endif
-#ifdef TPM_ALG_OAEP
 	case TPM_ALG_OAEP:
 			Unmarshal_TPMS_ENC_SCHEME_OAEP( sysContext, &asymScheme->oaep );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_ATTEST.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_ATTEST.c
@@ -42,41 +42,27 @@ void Unmarshal_TPMU_ATTEST(
 
 	switch( selector )
 	{
-#ifdef TPM_ST_ATTEST_CERTIFY
 	case TPM_ST_ATTEST_CERTIFY:
 			Unmarshal_TPMS_CERTIFY_INFO( sysContext, &attest->certify );
 			break;
-#endif
-#ifdef TPM_ST_ATTEST_CREATION
 	case TPM_ST_ATTEST_CREATION:
 			Unmarshal_TPMS_CREATION_INFO( sysContext, &attest->creation );
 			break;
-#endif
-#ifdef TPM_ST_ATTEST_QUOTE
 	case TPM_ST_ATTEST_QUOTE:
 			Unmarshal_TPMS_QUOTE_INFO( sysContext, &attest->quote );
 			break;
-#endif
-#ifdef TPM_ST_ATTEST_COMMAND_AUDIT
 	case TPM_ST_ATTEST_COMMAND_AUDIT:
 			Unmarshal_TPMS_COMMAND_AUDIT_INFO( sysContext, &attest->commandAudit );
 			break;
-#endif
-#ifdef TPM_ST_ATTEST_SESSION_AUDIT
 	case TPM_ST_ATTEST_SESSION_AUDIT:
 			Unmarshal_TPMS_SESSION_AUDIT_INFO( sysContext, &attest->sessionAudit );
 			break;
-#endif
-#ifdef TPM_ST_ATTEST_TIME
 	case TPM_ST_ATTEST_TIME:
 			Unmarshal_TPMS_TIME_ATTEST_INFO( sysContext, &attest->time );
 			break;
-#endif
-#ifdef TPM_ST_ATTEST_NV
 	case TPM_ST_ATTEST_NV:
 			Unmarshal_TPMS_NV_CERTIFY_INFO( sysContext, &attest->nv );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_CAPABILITIES.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_CAPABILITIES.c
@@ -42,51 +42,33 @@ void Unmarshal_TPMU_CAPABILITIES(
 
 	switch( selector )
 	{
-#ifdef TPM_CAP_ALGS
 	case TPM_CAP_ALGS:
 			Unmarshal_TPML_ALG_PROPERTY( sysContext, &capabilities->algorithms );
 			break;
-#endif
-#ifdef TPM_CAP_HANDLES
 	case TPM_CAP_HANDLES:
 			Unmarshal_TPML_HANDLE( sysContext, &capabilities->handles );
 			break;
-#endif
-#ifdef TPM_CAP_COMMANDS
 	case TPM_CAP_COMMANDS:
 			Unmarshal_TPML_CCA( sysContext, &capabilities->command );
 			break;
-#endif
-#ifdef TPM_CAP_PP_COMMANDS
 	case TPM_CAP_PP_COMMANDS:
 			Unmarshal_TPML_CC( sysContext, &capabilities->ppCommands );
 			break;
-#endif
-#ifdef TPM_CAP_AUDIT_COMMANDS
 	case TPM_CAP_AUDIT_COMMANDS:
 			Unmarshal_TPML_CC( sysContext, &capabilities->auditCommands );
 			break;
-#endif
-#ifdef TPM_CAP_PCRS
 	case TPM_CAP_PCRS:
 			Unmarshal_TPML_PCR_SELECTION( sysContext, &capabilities->assignedPCR );
 			break;
-#endif
-#ifdef TPM_CAP_TPM_PROPERTIES
 	case TPM_CAP_TPM_PROPERTIES:
 			Unmarshal_TPML_TAGGED_TPM_PROPERTY( sysContext, &capabilities->tpmProperties );
 			break;
-#endif
-#ifdef TPM_CAP_PCR_PROPERTIES
 	case TPM_CAP_PCR_PROPERTIES:
 			Unmarshal_TPML_TAGGED_PCR_PROPERTY( sysContext, &capabilities->pcrProperties );
 			break;
-#endif
-#ifdef TPM_CAP_ECC_CURVES
 	case TPM_CAP_ECC_CURVES:
 			Unmarshal_TPML_ECC_CURVE( sysContext, &capabilities->eccCurves );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_HA.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_HA.c
@@ -44,16 +44,6 @@ void Unmarshal_TPMU_HA(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_SHA
-	case TPM_ALG_SHA:
-
-	for( i = 0; i < SHA_DIGEST_SIZE; i++ )
-	{
-		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha[i], &( SYS_CONTEXT->rval ) );
-	}
-			break;
-#endif
-#ifdef TPM_ALG_SHA1
 	case TPM_ALG_SHA1:
 
 	for( i = 0; i < SHA1_DIGEST_SIZE; i++ )
@@ -61,8 +51,6 @@ void Unmarshal_TPMU_HA(
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha1[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SHA256
 	case TPM_ALG_SHA256:
 
 	for( i = 0; i < SHA256_DIGEST_SIZE; i++ )
@@ -70,8 +58,6 @@ void Unmarshal_TPMU_HA(
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha256[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SHA384
 	case TPM_ALG_SHA384:
 
 	for( i = 0; i < SHA384_DIGEST_SIZE; i++ )
@@ -79,8 +65,6 @@ void Unmarshal_TPMU_HA(
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha384[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SHA512
 	case TPM_ALG_SHA512:
 
 	for( i = 0; i < SHA512_DIGEST_SIZE; i++ )
@@ -88,8 +72,6 @@ void Unmarshal_TPMU_HA(
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha512[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_SM3_256
 	case TPM_ALG_SM3_256:
 
 	for( i = 0; i < SM3_256_DIGEST_SIZE; i++ )
@@ -97,11 +79,8 @@ void Unmarshal_TPMU_HA(
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sm3_256[i], &( SYS_CONTEXT->rval ) );
 	}
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_KDF_SCHEME.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_KDF_SCHEME.c
@@ -42,30 +42,20 @@ void Unmarshal_TPMU_KDF_SCHEME(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_MGF1
 	case TPM_ALG_MGF1:
 			Unmarshal_TPMS_SCHEME_MGF1( sysContext, &kdfScheme->mgf1 );
 			break;
-#endif
-#ifdef TPM_ALG_KDF1_SP800_56A
 	case TPM_ALG_KDF1_SP800_56A:
 			Unmarshal_TPMS_SCHEME_KDF1_SP800_56A( sysContext, &kdfScheme->kdf1_sp800_56a );
 			break;
-#endif
-#ifdef TPM_ALG_KDF2
 	case TPM_ALG_KDF2:
 			Unmarshal_TPMS_SCHEME_KDF2( sysContext, &kdfScheme->kdf2 );
 			break;
-#endif
-#ifdef TPM_ALG_KDF1_SP800_108
 	case TPM_ALG_KDF1_SP800_108:
 			Unmarshal_TPMS_SCHEME_KDF1_SP800_108( sysContext, &kdfScheme->kdf1_sp800_108 );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_PUBLIC_ID.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_PUBLIC_ID.c
@@ -42,26 +42,18 @@ void Unmarshal_TPMU_PUBLIC_ID(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_KEYEDHASH
 	case TPM_ALG_KEYEDHASH:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&publicVarId->keyedHash );
 			break;
-#endif
-#ifdef TPM_ALG_SYMCIPHER
 	case TPM_ALG_SYMCIPHER:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&publicVarId->sym );
 			break;
-#endif
-#ifdef TPM_ALG_RSA
 	case TPM_ALG_RSA:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&publicVarId->rsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECC
 	case TPM_ALG_ECC:
 			Unmarshal_TPMS_ECC_POINT( sysContext, &publicVarId->ecc );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_PUBLIC_PARMS.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_PUBLIC_PARMS.c
@@ -42,26 +42,18 @@ void Unmarshal_TPMU_PUBLIC_PARMS(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_KEYEDHASH
 	case TPM_ALG_KEYEDHASH:
 			Unmarshal_TPMS_KEYEDHASH_PARMS( sysContext, &publicVarParms->keyedHashDetail );
 			break;
-#endif
-#ifdef TPM_ALG_SYMCIPHER
 	case TPM_ALG_SYMCIPHER:
 			Unmarshal_TPMS_SYMCIPHER_PARMS( sysContext, &publicVarParms->symDetail );
 			break;
-#endif
-#ifdef TPM_ALG_RSA
 	case TPM_ALG_RSA:
 			Unmarshal_TPMS_RSA_PARMS( sysContext, &publicVarParms->rsaDetail );
 			break;
-#endif
-#ifdef TPM_ALG_ECC
 	case TPM_ALG_ECC:
 			Unmarshal_TPMS_ECC_PARMS( sysContext, &publicVarParms->eccDetail );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_SCHEME_KEYEDHASH.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_SCHEME_KEYEDHASH.c
@@ -42,20 +42,14 @@ void Unmarshal_TPMU_SCHEME_KEYEDHASH(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_HMAC
 	case TPM_ALG_HMAC:
 			Unmarshal_TPMS_SCHEME_HMAC( sysContext, &schemeKeyedhash->hmac );
 			break;
-#endif
-#ifdef TPM_ALG_XOR
 	case TPM_ALG_XOR:
 			Unmarshal_TPMS_SCHEME_XOR( sysContext, &schemeKeyedhash->exclusiveOr );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_SENSITIVE_COMPOSITE.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_SENSITIVE_COMPOSITE.c
@@ -42,26 +42,18 @@ void Unmarshal_TPMU_SENSITIVE_COMPOSITE(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_RSA
 	case TPM_ALG_RSA:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&sensitiveComposite->rsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECC
 	case TPM_ALG_ECC:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&sensitiveComposite->ecc );
 			break;
-#endif
-#ifdef TPM_ALG_KEYEDHASH
 	case TPM_ALG_KEYEDHASH:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&sensitiveComposite->bits );
 			break;
-#endif
-#ifdef TPM_ALG_SYMCIPHER
 	case TPM_ALG_SYMCIPHER:
 			UNMARSHAL_SIMPLE_TPM2B_NO_SIZE_CHECK( sysContext, (TPM2B *)&sensitiveComposite->sym );
 			break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_SIGNATURE.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_SIGNATURE.c
@@ -42,45 +42,29 @@ void Unmarshal_TPMU_SIGNATURE(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_RSASSA
 	case TPM_ALG_RSASSA:
 			Unmarshal_TPMS_SIGNATURE_RSASSA( sysContext, &signature->rsassa );
 			break;
-#endif
-#ifdef TPM_ALG_RSAPSS
 	case TPM_ALG_RSAPSS:
 			Unmarshal_TPMS_SIGNATURE_RSAPSS( sysContext, &signature->rsapss );
 			break;
-#endif
-#ifdef TPM_ALG_ECDSA
 	case TPM_ALG_ECDSA:
 			Unmarshal_TPMS_SIGNATURE_ECDSA( sysContext, &signature->ecdsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECDAA
 	case TPM_ALG_ECDAA:
 			Unmarshal_TPMS_SIGNATURE_ECDAA( sysContext, &signature->ecdaa );
 			break;
-#endif
-#ifdef TPM_ALG_SM2
 	case TPM_ALG_SM2:
 			Unmarshal_TPMS_SIGNATURE_SM2( sysContext, &signature->sm2 );
 			break;
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	case TPM_ALG_ECSCHNORR:
 			Unmarshal_TPMS_SIGNATURE_ECSCHNORR( sysContext, &signature->ecschnorr );
 			break;
-#endif
-#ifdef TPM_ALG_HMAC
 	case TPM_ALG_HMAC:
 			Unmarshal_TPMT_HA( sysContext, &signature->hmac );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_SIG_SCHEME.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_SIG_SCHEME.c
@@ -42,45 +42,29 @@ void Unmarshal_TPMU_SIG_SCHEME(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_RSASSA
 	case TPM_ALG_RSASSA:
 			Unmarshal_TPMS_SIG_SCHEME_RSASSA( sysContext, &sigScheme->rsassa );
 			break;
-#endif
-#ifdef TPM_ALG_RSAPSS
 	case TPM_ALG_RSAPSS:
 			Unmarshal_TPMS_SIG_SCHEME_RSAPSS( sysContext, &sigScheme->rsapss );
 			break;
-#endif
-#ifdef TPM_ALG_ECDSA
 	case TPM_ALG_ECDSA:
 			Unmarshal_TPMS_SIG_SCHEME_ECDSA( sysContext, &sigScheme->ecdsa );
 			break;
-#endif
-#ifdef TPM_ALG_ECDAA
 	case TPM_ALG_ECDAA:
 			Unmarshal_TPMS_SIG_SCHEME_ECDAA( sysContext, &sigScheme->ecdaa );
 			break;
-#endif
-#ifdef TPM_ALG_SM2
 	case TPM_ALG_SM2:
 			Unmarshal_TPMS_SIG_SCHEME_SM2( sysContext, &sigScheme->sm2 );
 			break;
-#endif
-#ifdef TPM_ALG_ECSCHNORR
 	case TPM_ALG_ECSCHNORR:
 			Unmarshal_TPMS_SIG_SCHEME_ECSCHNORR( sysContext, &sigScheme->ecschnorr );
 			break;
-#endif
-#ifdef TPM_ALG_HMAC
 	case TPM_ALG_HMAC:
 			Unmarshal_TPMS_SCHEME_HMAC( sysContext, &sigScheme->hmac );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_SYM_KEY_BITS.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_SYM_KEY_BITS.c
@@ -42,30 +42,20 @@ void Unmarshal_TPMU_SYM_KEY_BITS(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_AES
 	case TPM_ALG_AES:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symKeyBits->aes, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_SM4
 	case TPM_ALG_SM4:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symKeyBits->sm4, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_CAMELLIA
 	case TPM_ALG_CAMELLIA:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symKeyBits->camellia, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_XOR
 	case TPM_ALG_XOR:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symKeyBits->exclusiveOr, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }

--- a/sysapi/sysapi_util/Unmarshal_TPMU_SYM_MODE.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_SYM_MODE.c
@@ -42,29 +42,19 @@ void Unmarshal_TPMU_SYM_MODE(
 
 	switch( selector )
 	{
-#ifdef TPM_ALG_AES
 	case TPM_ALG_AES:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symMode->aes, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_SM4
 	case TPM_ALG_SM4:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symMode->sm4, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_CAMELLIA
 	case TPM_ALG_CAMELLIA:
 			Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &symMode->camellia, &( SYS_CONTEXT->rval ) );
 			break;
-#endif
-#ifdef TPM_ALG_XOR
 	case TPM_ALG_XOR:
 					break;
-#endif
-#ifdef TPM_ALG_NULL
 	case TPM_ALG_NULL:
 					break;
-#endif
 	}
 	return;
 }


### PR DESCRIPTION
The selective enabling / disabling of these things makes little sense for the TSS. Removal greatly simplifies the code.