### PR TITLE
sapi: Add Tss2_Tcti_Finalize() to the API

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -155,6 +155,11 @@ TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
 
 typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
 
+// function that is equivalent to the tss2_tcti_finalize macro
+TSS2_RC Tss2_Tcti_Finalize(
+    TSS2_TCTI_CONTEXT *tctiContext
+    );
+
 #ifdef __cplusplus
 }
 #endif

--- a/sysapi/sysapi/Tss2_Tcti_Finalize.c
+++ b/sysapi/sysapi/Tss2_Tcti_Finalize.c
@@ -1,0 +1,47 @@
+//**********************************************************************;
+// Copyright (c) 2015, 2016, Intel Corporation
+// Copyright (c) 2017, Star Lab Corp.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include "sapi/tpm20.h"
+#include "sysapi_util.h"
+
+TSS2_RC Tss2_Tcti_Finalize(
+    TSS2_TCTI_CONTEXT *tctiContext
+    )
+{
+    if (!tctiContext)
+        return TSS2_TCTI_RC_BAD_VALUE;
+    if (TSS2_TCTI_VERSION(tctiContext) < 1)
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    if (!TSS2_TCTI_FINALIZE(tctiContext))
+        return TSS2_RC_SUCCESS;
+
+    TSS2_TCTI_FINALIZE(tctiContext)(tctiContext);
+
+    return TSS2_RC_SUCCESS;
+}
+


### PR DESCRIPTION
Added an explicit Tss2_Tcti_Finalize() to the API to avoid issues with
languages trying to wrap up this API via a FFI. By exposing this method
only via a macro on an opaque structure it becomes impossible to call it
from an FFI. But by providing an explicit function it can now be called.
I left the existing tss2_tcti_finalize() macro because some code
(specifically the unit tests) link to the TCTI libraries only. In these
cases the new function would not be available. The function cannot be
provided by the TCTI library since many programs link all of them in
when they use the SAPI and that would cause a conflict. So both are
available to preserve compatibility. Refs #490.

Signed-off-by: Doug Goldstein <cardoe@cardoe.com>