### PR TITLE
implementation.h: Remove undef of TRUE and FALSE macros.

### DIFF
--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -35,9 +35,6 @@
 #ifndef _IMPLEMENTATION_H_
 #define _IMPLEMENTATION_H_
 
-#undef TRUE
-#undef FALSE
-
 // From TPM 2.0 Part 2: Table 4 - Defines for Logic Values
 #define  YES      1
 #define  NO       0


### PR DESCRIPTION
This fixes a bug caused by 01e1e12965d747f5d95760baf931850e69294334
which removed the macro defining TRUE and FALSE but didn't remove the
preceding undef. This causes these macros to be undefined by the TSS2
headers even though they may have been defined by some other header
(like glib in the case of the tabrmd).

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>