### PR TITLE
TSS2_Sys_LoadExternal: Fix marshaling error

### DIFF
--- a/sysapi/sysapi/Tss2_Sys_LoadExternal.c
+++ b/sysapi/sysapi/Tss2_Sys_LoadExternal.c
@@ -44,12 +44,14 @@ TPM_RC Tss2_Sys_LoadExternal_Prepare(
 
     CommonPreparePrologue( sysContext, TPM_CC_LoadExternal );
 
-    if( inPrivate == 0 )
-	{
+    /* If no private key is specified, set the private key size field (UINT16) to 0 */
+    if(inPrivate != NULL)
+    {
+        Marshal_TPM2B_SENSITIVE( sysContext, inPrivate );
+    } else {
 		SYS_CONTEXT->decryptNull = 1;
-	}
-
-    Marshal_TPM2B_SENSITIVE( sysContext, inPrivate );
+        Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), 0, &(SYS_CONTEXT->rval) );
+    }
 
     Marshal_TPM2B_PUBLIC( sysContext, inPublic );
 

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -3293,7 +3293,10 @@ void TestUnseal()
     INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_LoadExternal ( sysContext, 0, 0, &outPublic,
             TPM_RH_PLATFORM, &loadedObjectHandle, &name, 0 );
-    CheckFailed( rval,  TSS2_TYPES_RC_BAD_REFERENCE);
+    CheckPassed( rval );
+
+    rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle );
+    CheckPassed( rval );
 
     INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_Load ( sysContext, handle2048rsa, &sessionsData, &outPrivate, &outPublic,


### PR DESCRIPTION
Commit 60dcc re-places the old marshaling code with the newer
marshaling code. This commit, introduced a breakagae in
tpm2_loadexternal tool when a private key was not specified.

In the case of a NULL private key, the Tss2_Sys_LoadExternal
call should set the size field of the Private Key to 0.

Fixes: #496

Signed-off-by: William Roberts <william.c.roberts@intel.com>