### PR TITLE
fix auto-generated pkgconfig files for libsapi

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -243,6 +243,7 @@ TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES)
 %.pc : %.pc.in
 	$(call make_parent_dir,$@)
 	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
+	        s,[@]libdir[@],$(libdir),g; \
 	        s,[@]includedir[@],$(includedir),g;" $^ > $@
 
 man/man3/%.3 : man/%.3.in $(srcdir)/man/man-postlude.troff

--- a/lib/sapi.pc.in
+++ b/lib/sapi.pc.in
@@ -2,5 +2,5 @@ Name: sapi
 Description: TPM2 System API library.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
-Cflags: -I@includedir@/sapi
-Libs: -lmarshal -lsapi
+Cflags: -I@includedir@
+Libs: -lmarshal -lsapi -L@libdir@

--- a/lib/tcti-device.pc.in
+++ b/lib/tcti-device.pc.in
@@ -3,5 +3,5 @@ Description: TCTI library for communicating with a TPM device node.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
 Requires: sapi
-Cflags: -I@includedir@/tcti
-Libs: -ltcti-device
+Cflags: -I@includedir@
+Libs: -ltcti-device -L@libdir@

--- a/lib/tcti-socket.pc.in
+++ b/lib/tcti-socket.pc.in
@@ -3,5 +3,5 @@ Description: TCTI library for communicating with a TPM over a socket.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
 Requires: sapi
-Cflags: -I@includedir@/tcti
-Libs: -ltcti-socket
+Cflags: -I@includedir@
+Libs: -ltcti-socket -L@libdir@


### PR DESCRIPTION
fix auto-generated pkgconfig files to allow us to install libsapi.a into a customized directory, e.g. /opt/xxx