### PR TITLE
build: Switch travis from virtual machine to containers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-language: cpp
+language: c
 compiler:
   - gcc
   - clang
 
-# This is a lie: we don't need sudo but this is required to get an
-# Ubuntu image with a libc that isn't ancient, and with cmocka libs.
-sudo: required
+sudo: false
 dist: trusty
 
 env:


### PR DESCRIPTION
This gets us a faster turn around time on each build:
https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
Additionally it allows developers to use a local travis coantainer to
build / test locally.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>