### PR TITLE
build: Fix 'dist' and 'distcheck' target.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   - mkdir ./build
   - pushd ./build
   - ../configure --enable-unit --with-simulatorbin=$(pwd)/../ibmtpm532/src/tpm_server
-  - make -j$(nproc)
+  - make -j$(nproc) distcheck
   - make -j$(nproc) check
   - |
     for LOG in $(ls -1 test/unit/*.log); do

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,10 @@ endif #SIMULATOR_BIN
 CLEANFILES = \
     $(nodist_pkgconfig_DATA) \
     $(man3_MANS) \
-    $(man7_MANS)
+    $(man7_MANS) \
+    test/integration/*.log \
+    test/tpmclient/*.log \
+    test/unit/*.log
 
 # headers and where to install them
 libsapidir      = $(includedir)/sapi
@@ -101,6 +104,7 @@ EXTRA_DIST = \
     man/man3/InitSocketTcti.3 \
     man/tcti-device.7.in \
     man/tcti-socket.7.in \
+    $(INT_LOG_COMPILER) \
     tcti/tcti_device.map \
     tcti/tcti_socket.map
 
@@ -158,7 +162,7 @@ test_unit_TPMA_marshal_SOURCES = test/unit/TPMA-marshal.c
 endif # UNIT
 
 marshal_libmarshal_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/libmarshal.map
-marshal_libmarshal_la_SOURCES = $(MARSHAL_SRC) log/log.c
+marshal_libmarshal_la_SOURCES = $(MARSHAL_SRC) log/log.c log/log.h
 
 sysapi_libsapi_la_LIBADD  = $(libmarshal)
 sysapi_libsapi_la_SOURCES = $(SYSAPI_C) $(SYSAPI_H) $(SYSAPIUTIL_C) \

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([tpm2.0-tss],
+AC_INIT([tpm2-tss],
         [m4_esyscmd_s([git describe --tags --always --dirty])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
@@ -6,6 +6,10 @@ LT_INIT()
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])
+
+# propagate configure arguments to distcheck
+AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
+
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
                             [build cmocka unit tests (default is no)])],


### PR DESCRIPTION
There are a few small changes here but all are required to get proper
release tarballs made by dist / distcheck.

The project name in configure.ac needed to be updated to account for the
project name change from TPM2.0-TSS to tpm2-tss. Also the options passed
to the configure script need to be propagated to the distcheck target.
This is accomplished by setting the DISTCHECK_CONFIGURE_FLAGS when the
configure script generates the Makefile.

In Makefile.am we add all of the log files generated by the test harness
to CLEAN_FILES to ensure they don't end up in the distribution tarball.
We also add the integration test log compilation script to EXTRA_DIST to
ensure it makes it into the distribution. Finally we add the log.h file
to marshal_libmarshal_la_SOURCES as it won't make it into the release
tarball otherwise.

Finally we add explicit execution of the distcheck target to the
.travis.yml file to ensure future breakage is detected early.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>