### PR TITLE
marshal: Fix null pointer dereference int TPM2B

### DIFF
--- a/marshal/tpm2b-types.c
+++ b/marshal/tpm2b-types.c
@@ -245,7 +245,7 @@ TSS2_RC type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
              sizeof(size)); \
         return TSS2_TYPES_RC_INSUFFICIENT_BUFFER; \
     } \
-    if (dest->t.size != 0) { \
+    if (dest && dest->t.size != 0) { \
         LOG (WARNING, "Size not zero"); \
         return TSS2_SYS_RC_BAD_VALUE; \
     } \


### PR DESCRIPTION
The logic in TPM2B_*_Unmashal should be that, when the dest in NULL
and offset is valid, the offset should be updated, and nothing should
be written to the buffer.
Currently the implementation dereferences the dest causing a segfault.