### PR TITLE
pkg-config: TCTI libraries depend on libmarshal, not libsapi.

### DIFF
--- a/lib/tcti-device.pc.in
+++ b/lib/tcti-device.pc.in
@@ -2,6 +2,6 @@ Name: tcti-device
 Description: TCTI library for communicating with a TPM device node.
 URL: https://github.com/01org/tpm2-tss
 Version: @VERSION@
-Requires: sapi
+Requires: marshal
 Cflags: -I@includedir@
 Libs: -ltcti-device -L@libdir@

--- a/lib/tcti-socket.pc.in
+++ b/lib/tcti-socket.pc.in
@@ -2,6 +2,6 @@ Name: tcti-socket
 Description: TCTI library for communicating with a TPM over a socket.
 URL: https://github.com/01org/tpm2-tss
 Version: @VERSION@
-Requires: sapi
+Requires: marshal
 Cflags: -I@includedir@
 Libs: -ltcti-socket -L@libdir@


### PR DESCRIPTION
The dependency on sapi came from the fact that the TCTIs used the type
marshalling functions and they were packaged in libsapi. They were not
standardized and we shouldn't have been exposing them to consumers
really but we did.

Now that this is fixed and we have libmarshal the TCTIs should depend on
it directly and remove the libsapi dependency.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>