### PR TITLE
libmarshal.map: Don't expose endian conversion functions.

### DIFF
--- a/lib/libmarshal.map
+++ b/lib/libmarshal.map
@@ -1,11 +1,5 @@
 {
     global:
-        # convenience functions to convert endianness
-        endian_conv_8;
-        endian_conv_16;
-        endian_conv_32;
-        endian_conv_64;
-        # marshalling functions for TPM2 types
         BYTE_Marshal;
         BYTE_Unmarshal;
         INT8_Marshal;


### PR DESCRIPTION
There are already too many places to get endian conversion functions
(compiler built-ins, endian.h etc).

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>