### PR TITLE
INSTALL.md: Add note on how to build from source in Fedora

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,6 +33,15 @@ $ sudo apt -y install \
   autoconf
 ```
 
+## Fedora
+
+There is a package already, so the package build dependencies information can be
+used to make sure that the needed packages to compile from source are installed:
+
+```
+$ sudo dnf builddep tpm2-tss
+```
+
 # Building From Source
 ## Bootstrapping the Build
 To configure the tpm2.0-tss source code first run the bootstrap script, which


### PR DESCRIPTION
The INSTALL.md file has instructions on how to build tpm2-tss from source
in other distros, add also a note on the steps needed to do it in Fedora.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>