### PR TITLE
Revert "configure: use -fpack-struct instead of pragmas"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,6 @@ AX_ADD_COMPILER_FLAG([-Wformat-security])
 AX_ADD_COMPILER_FLAG([-fstack-protector-all])
 AX_ADD_COMPILER_FLAG([-fpic])
 AX_ADD_COMPILER_FLAG([-fPIC])
-AX_ADD_COMPILER_FLAG([-fpack-struct])
 
 AC_ARG_ENABLE([debug],
             [AS_HELP_STRING([--enable-debug],

--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -103,6 +103,7 @@ typedef struct {
 
 #define SYS_CONTEXT ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )
 
+#pragma pack(push, 1)
 //
 // Generic header
 //
@@ -124,6 +125,8 @@ typedef struct _TPM20_ErrorResponse {
   UINT32 responseSize;
   UINT32 responseCode;
 } TPM20_ErrorResponse;
+
+#pragma pack(pop)
 
 typedef struct {
     TPM_CC commandCode;


### PR DESCRIPTION
This reverts commit 82a2ff9cec3169d33e1ad4433b074d399002f1c0.

Packing the public structures causes an ABI mismatch
between consumers of TSS public structures.

Fixes: #531