### PR TITLE
add check for count in TPML

### DIFF
--- a/marshal/tpml-types.c
+++ b/marshal/tpml-types.c
@@ -36,6 +36,7 @@
 
 #define ADDR &
 #define VAL
+#define TAB_SIZE(tab) (sizeof(tab) / sizeof(tab[0]))
 
 #define TPML_MARSHAL(type, marshal_func, buf_name, op) \
 TSS2_RC type##_Marshal(type const *src, uint8_t buffer[], \
@@ -69,6 +70,11 @@ TSS2_RC type##_Marshal(type const *src, uint8_t buffer[], \
              local_offset, \
              sizeof(count)); \
         return TSS2_TYPES_RC_INSUFFICIENT_BUFFER; \
+    } \
+\
+    if (src->count > TAB_SIZE(src->buf_name)) { \
+        LOG (WARNING, "count too big"); \
+        return TSS2_SYS_RC_BAD_VALUE; \
     } \
 \
     if (buf_ptr == NULL) \
@@ -141,6 +147,11 @@ TSS2_RC type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
     ret = UINT32_Unmarshal(buffer, buffer_size, &local_offset, &count); \
     if (ret) \
         return ret; \
+\
+    if (count > TAB_SIZE(dest->buf_name)) { \
+        LOG (WARNING, "count too big"); \
+        return TSS2_SYS_RC_MALFORMED_RESPONSE; \
+    } \
 \
     dest->count = count; \
 \

--- a/marshal/tpms-types.c
+++ b/marshal/tpms-types.c
@@ -36,6 +36,7 @@
 
 #define ADDR &
 #define VAL
+#define TAB_SIZE(tab) (sizeof(tab) / sizeof(tab[0]))
 
 static TSS2_RC marshal_pcr_select(const UINT8 *ptr, uint8_t buffer[],
                                   size_t buffer_size, size_t *offset)
@@ -52,6 +53,11 @@ static TSS2_RC marshal_pcr_select(const UINT8 *ptr, uint8_t buffer[],
     ret = UINT8_Marshal(pcrSelect->sizeofSelect, buffer, buffer_size, offset);
     if (ret)
         return ret;
+
+    if (pcrSelect->sizeofSelect > TAB_SIZE(pcrSelect->pcrSelect)) {
+        LOG (ERROR, "sizeofSelect value too big");
+        return TSS2_SYS_RC_BAD_VALUE;
+    }
 
     for (i = 0; i < pcrSelect->sizeofSelect; i++)
     {
@@ -79,6 +85,11 @@ static TSS2_RC unmarshal_pcr_select(uint8_t const buffer[], size_t buffer_size,
     if (ret)
         return ret;
 
+    if (pcrSelect->sizeofSelect > TAB_SIZE(pcrSelect->pcrSelect)) {
+        LOG (ERROR, "sizeofSelect value too big");
+        return TSS2_SYS_RC_MALFORMED_RESPONSE;
+    }
+
     for (i = 0; i < pcrSelect->sizeofSelect; i++)
     {
         ret = UINT8_Unmarshal(buffer, buffer_size, offset, &pcrSelect->pcrSelect[i]);
@@ -100,6 +111,11 @@ static TSS2_RC marshal_pcr_selection(const TPMI_ALG_HASH *ptr, uint8_t buffer[],
     if (ptr == NULL) {
         LOG (WARNING, "src param is NULL");
         return TSS2_TYPES_RC_BAD_REFERENCE;
+    }
+
+    if (pcrSelection->sizeofSelect > TAB_SIZE(pcrSelection->pcrSelect)) {
+        LOG (ERROR, "sizeofSelect value too big");
+        return TSS2_SYS_RC_BAD_VALUE;
     }
 
     ret = UINT16_Marshal(pcrSelection->hash, buffer, buffer_size, offset);
@@ -141,6 +157,11 @@ static TSS2_RC unmarshal_pcr_selection(uint8_t const buffer[], size_t buffer_siz
     if (ret)
         return ret;
 
+    if (pcrSelection->sizeofSelect > TAB_SIZE(pcrSelection->pcrSelect)) {
+        LOG (ERROR, "sizeofSelect value too big");
+        return TSS2_SYS_RC_MALFORMED_RESPONSE;
+    }
+
     for (i = 0; i < pcrSelection->sizeofSelect; i++)
     {
         ret = UINT8_Unmarshal(buffer, buffer_size, offset, &pcrSelection->pcrSelect[i]);
@@ -162,6 +183,11 @@ static TSS2_RC marshal_tagged_pcr_selection(const TPM_PT_PCR *ptr, uint8_t buffe
     if (ptr == NULL) {
         LOG (WARNING, "src param is NULL");
         return TSS2_TYPES_RC_BAD_REFERENCE;
+    }
+
+    if (taggedPcrSelect->sizeofSelect > TAB_SIZE(taggedPcrSelect->pcrSelect)) {
+        LOG (ERROR, "sizeofSelect value too big");
+        return TSS2_SYS_RC_BAD_VALUE;
     }
 
     ret = UINT32_Marshal(taggedPcrSelect->tag, buffer, buffer_size, offset);
@@ -201,6 +227,11 @@ static TSS2_RC unmarshal_tagged_pcr_selection(uint8_t const buffer[], size_t buf
     ret = UINT8_Unmarshal(buffer, buffer_size, offset, &taggedPcrSelect->sizeofSelect);
     if (ret)
         return ret;
+
+    if (taggedPcrSelect->sizeofSelect > TAB_SIZE(taggedPcrSelect->pcrSelect)) {
+        LOG (ERROR, "sizeofSelect value too big");
+        return TSS2_SYS_RC_MALFORMED_RESPONSE;
+    }
 
     for (i = 0; i < taggedPcrSelect->sizeofSelect; i++)
     {

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -1367,7 +1367,7 @@ void TestPcrExtend()
     pcrSelection.pcrSelections[0].sizeofSelect = 4;
 
     rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrSelection, &pcrUpdateCounterAfterExtend, 0, 0, 0 );
-    CheckFailed( rval, TPM_RC_1 + TPM_RC_P + TPM_RC_VALUE );
+    CheckFailed( rval, TSS2_SYS_RC_BAD_VALUE );
 
     eventData.t.size = 4;
     eventData.t.buffer[0] = 0;


### PR DESCRIPTION
While (un)marshalling TPML types the count needs to be
verified before the table is read/written to.
