### PR TITLE
configure: Add compiler flag to ignore int-in-bool-context errors fro…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
 
 AX_ADD_COMPILER_FLAG([-Wall])
 AX_ADD_COMPILER_FLAG([-Werror])
+AX_ADD_COMPILER_FLAG([-Wno-int-in-bool-context])
 AX_ADD_COMPILER_FLAG([-Wformat])
 AX_ADD_COMPILER_FLAG([-Wformat-security])
 AX_ADD_COMPILER_FLAG([-fstack-protector-all])


### PR DESCRIPTION
…m GCC 7.

The offending code has already been removed from the master branch.
We can't remove these identifiers from the 1.x branch w/o breaking
backward compatability. GCC 7 doesn't like how we use them though so
we've gotta ignore the warnings it spits out.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>