### PR TITLE
tpmclient: Fix misleading indentation.

### DIFF
--- a/test/tpmclient/tpmclient.int.cpp
+++ b/test/tpmclient/tpmclient.int.cpp
@@ -1447,9 +1447,9 @@ void TestNV()
     for( i = 0; i < nvAuth.t.size; i++ )
         nvAuth.t.buffer[i] = (UINT8)i;
 
-	publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
-            sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-            sizeof( UINT16 );
+    publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
+        sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
+        sizeof( UINT16 );
     publicInfo.t.nvPublic.nvIndex = TPM20_INDEX_TEST1;
     publicInfo.t.nvPublic.nameAlg = TPM_ALG_SHA1;
 
@@ -1606,9 +1606,9 @@ void TestHierarchyControl()
     for( i = 0; i < nvAuth.t.size; i++ )
         nvAuth.t.buffer[i] = i;
 
-	publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
-            sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-            sizeof( UINT16 );
+    publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
+        sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
+        sizeof( UINT16 );
     publicInfo.t.nvPublic.nvIndex = TPM20_INDEX_TEST1;
     publicInfo.t.nvPublic.nameAlg = TPM_ALG_SHA1;
 
@@ -3360,9 +3360,9 @@ void CreatePasswordTestNV( TPMI_RH_NV_INDEX nvIndex, char * password )
     for( i = 0; i < nvAuth.t.size; i++ )
         nvAuth.t.buffer[i] = password[i];
 
-	publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
-            sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
-            sizeof( UINT16 );
+    publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
+        sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
+        sizeof( UINT16 );
     publicInfo.t.nvPublic.nvIndex = nvIndex;
     publicInfo.t.nvPublic.nameAlg = TPM_ALG_SHA1;
 


### PR DESCRIPTION
GCC 7 is much more picky about this stuff.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>