### PR TITLE
1.x travis clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ install:
   - mkdir ibmtpm532
   - tar axf ibmtpm532.tar -C ibmtpm532
   - make -C ibmtpm532/src -j$(nproc)
-  - wget https://cmocka.org/files/1.0/cmocka-1.0.1.tar.xz
-  - tar -Jxvf cmocka-1.0.1.tar.xz
+  - wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
+  - tar -Jxvf cmocka-1.1.1.tar.xz
   - mkdir cmocka
-  - cd cmocka-1.0.1
+  - cd cmocka-1.1.1
   - mkdir build
   - cd build
   - cmake ../ -DCMAKE_INSTALL_PREFIX=../../cmocka -DCMAKE_BUILD_TYPE=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 compiler:
   - gcc
+  - clang
 
 sudo: false
 dist: trusty

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -11,7 +11,8 @@ AC_DEFUN([AX_ADD_COMPILER_FLAG],[
         AS_IF([test x$2 != xrequired],[
             AC_MSG_WARN([Optional CFLAG "$1" not supported by your compiler, continuing.])],[
             AC_MSG_ERROR([Required CFLAG "$1" not supported by your compiler, aborting.])]
-        )]
+        )],[
+        -Wall -Werror]
     )]
 )
 dnl AX_ADD_PREPROC_FLAG:


### PR DESCRIPTION
Fixing the clang build is necessary to support the tabrmd 1.x branch. These are just infrastructure / build fixups to keep clang happy. b0ec72f should be picked into master as well.