### PR TITLE
build: Cause warnings to be errors when checking for compiler flag su…

### DIFF
--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -11,7 +11,8 @@ AC_DEFUN([AX_ADD_COMPILER_FLAG],[
         AS_IF([test x$2 != xrequired],[
             AC_MSG_WARN([Optional CFLAG "$1" not supported by your compiler, continuing.])],[
             AC_MSG_ERROR([Required CFLAG "$1" not supported by your compiler, aborting.])]
-        )]
+        )],[
+        -Wall -Werror]
     )]
 )
 dnl AX_ADD_PREPROC_FLAG:


### PR DESCRIPTION
…pport.

This was the original intent I just didn't understand how the macro works.
Turns out that warnings are ignored so if a compiler flag that's not supported
only causes a warning then it's considered "supported" and will be included
in CFLAGS with the macro as it was. But since we make all warnings errors
when we build, the unsupported flag causes a build failure. With this patch
causes unsupported, optional compiler flags to be dropped.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>