### PR TITLE
build: Cause warnings to be errors when checking for preprocessor fla…

### DIFF
--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -30,7 +30,8 @@ AC_DEFUN([AX_ADD_PREPROC_FLAG],[
         AS_IF([test x$2 != xrequired],[
             AC_MSG_WARN([Optional preprocessor flag "$1" not supported by your compiler, continuing.])],[
             AC_MSG_ERROR([Required preprocessor flag "$1" not supported by your compiler, aborting.])]
-        )]
+        )],[
+        -Wall -Werror]
     )]
 )
 dnl AX_ADD_LINK_FLAG:


### PR DESCRIPTION
…g support.

This is a continuation of the work from ce8b05ed45c83064f559727527ef3ab9a56c8796.
It may be that the preprocessor will issue a warning for an unsupported flag
instead of an error. Since we build with -Werror & -Wall we must ensure that
all warnings are treated as errors when we're checking for supported flags.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>