### PR TITLE
tcti: Repurpose TCTI_CONTEXT_INTEL macro as a cast macro and local va…

### DIFF
--- a/tcti/commonchecks.c
+++ b/tcti/commonchecks.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015, 2017 Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -38,18 +38,20 @@ TSS2_RC CommonSendChecks(
     uint8_t           *command_buffer     /* in */
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
+
     if( tctiContext == NULL || command_buffer == NULL )
     {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
 
-    if (TCTI_CONTEXT_INTEL->previousStage == TCTI_STAGE_SEND_COMMAND)
+    if (tcti_intel->previousStage == TCTI_STAGE_SEND_COMMAND)
     {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
 
-    if (TCTI_CONTEXT_INTEL->magic != TCTI_MAGIC ||
-        TCTI_CONTEXT_INTEL->version != TCTI_VERSION)
+    if (tcti_intel->magic != TCTI_MAGIC ||
+        tcti_intel->version != TCTI_VERSION)
     {
         return TSS2_TCTI_RC_BAD_CONTEXT;
     }
@@ -64,18 +66,20 @@ TSS2_RC CommonReceiveChecks(
     unsigned char   *response_buffer    /* in */
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
+
     if( tctiContext == NULL || response_size == NULL )
     {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
 
-    if (TCTI_CONTEXT_INTEL->previousStage == TCTI_STAGE_RECEIVE_RESPONSE)
+    if (tcti_intel->previousStage == TCTI_STAGE_RECEIVE_RESPONSE)
     {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
 
-    if (TCTI_CONTEXT_INTEL->magic != TCTI_MAGIC ||
-        TCTI_CONTEXT_INTEL->version != TCTI_VERSION)
+    if (tcti_intel->magic != TCTI_MAGIC ||
+        tcti_intel->version != TCTI_VERSION)
     {
         return TSS2_TCTI_RC_BAD_CONTEXT;
     }

--- a/tcti/platformcommand.c
+++ b/tcti/platformcommand.c
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015, 2017 Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -54,6 +54,7 @@ TSS2_RC PlatformCommand(
     TSS2_TCTI_CONTEXT *tctiContext,     /* in */
     char cmd )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     int iResult = 0;            // used to return function results
     char sendbuf[] = { 0x0,0x0,0x0,0x0 };
     char recvbuf[] = { 0x0, 0x0, 0x0, 0x0 };
@@ -62,7 +63,7 @@ TSS2_RC PlatformCommand(
     sendbuf[3] = cmd;
 
     // Send the command
-    iResult = send( TCTI_CONTEXT_INTEL->otherSock, sendbuf, 4, MSG_NOSIGNAL );
+    iResult = send (tcti_intel->otherSock, sendbuf, 4, MSG_NOSIGNAL);
     if (iResult == SOCKET_ERROR) {
         TCTI_LOG( tctiContext, NO_PREFIX, "send failed with error: %d\n", WSAGetLastError() );
         rval = TSS2_TCTI_RC_IO_ERROR;
@@ -70,14 +71,14 @@ TSS2_RC PlatformCommand(
     else
     {
 #ifdef DEBUG_SOCKETS
-        TCTI_LOG( tctiContext, NO_PREFIX, "Send Bytes to socket #0x%x: \n", TCTI_CONTEXT_INTEL->otherSock );
+        TCTI_LOG( tctiContext, NO_PREFIX, "Send Bytes to socket #0x%x: \n", tcti_intel->otherSock );
         TCTI_LOG_BUFFER( tctiContext, NO_PREFIX, (UINT8 *)sendbuf, 4 );
 #endif
         // Read result
-        iResult = recv( TCTI_CONTEXT_INTEL->otherSock, recvbuf, 4, 0);
+        iResult = recv( tcti_intel->otherSock, recvbuf, 4, 0);
         if (iResult == SOCKET_ERROR) {
             TCTI_LOG( tctiContext, NO_PREFIX, "In PlatformCommand, recv failed (socket: 0x%x) with error: %d\n",
-                    TCTI_CONTEXT_INTEL->otherSock, WSAGetLastError() );
+                    tcti_intel->otherSock, WSAGetLastError() );
             rval = TSS2_TCTI_RC_IO_ERROR;
         }
         else if( recvbuf[0] != 0 || recvbuf[1] != 0 || recvbuf[2] != 0 || recvbuf[3] != 0 )
@@ -88,7 +89,7 @@ TSS2_RC PlatformCommand(
         else
         {
 #ifdef DEBUG_SOCKETS
-            TCTI_LOG( tctiContext, NO_PREFIX, "Receive bytes from socket #0x%x: \n", TCTI_CONTEXT_INTEL->otherSock );
+            TCTI_LOG( tctiContext, NO_PREFIX, "Receive bytes from socket #0x%x: \n", tcti_intel->otherSock );
             TCTI_LOG_BUFFER( tctiContext, NO_PREFIX, (UINT8 *)recvbuf, 4 );
 #endif
         }

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015, 2017 Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,6 @@
 #define TCTI_LOG_DATA(ctx)     ((TSS2_TCTI_CONTEXT_INTEL*)ctx)->logData
 #define TCTI_LOG_BUFFER_CALLBACK(ctx) ((TSS2_TCTI_CONTEXT_INTEL*)ctx)->logBufferCallback
 #define TCTI_CONTEXT ((TSS2_TCTI_CONTEXT_COMMON_CURRENT *)(SYS_CONTEXT->tctiContext))
-#define TCTI_CONTEXT_INTEL ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)
 
 typedef TSS2_RC (*TCTI_TRANSMIT_PTR)( TSS2_TCTI_CONTEXT *tctiContext, size_t size, uint8_t *command);
 typedef TSS2_RC (*TCTI_RECEIVE_PTR) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size, uint8_t *response, int32_t timeout);
@@ -104,5 +103,16 @@ typedef struct {
     TCTI_LOG_BUFFER_CALLBACK logBufferCallback;
     void *logData;
 } TSS2_TCTI_CONTEXT_INTEL;
+
+/*
+ * This function is used to "up cast" the common TCTI interface type to the
+ * private type used in the implementation. This is how we control access to
+ * the data below the 'setLocality' function.
+ */
+static inline TSS2_TCTI_CONTEXT_INTEL*
+tcti_context_intel_cast (TSS2_TCTI_CONTEXT *ctx)
+{
+    return (TSS2_TCTI_CONTEXT_INTEL*)ctx;
+}
 
 #endif

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -74,6 +74,7 @@ TSS2_RC SendSessionEndSocketTcti(
     TSS2_TCTI_CONTEXT *tctiContext,       /* in */
     UINT8 tpmCmdServer )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     // Value for "send command" to MS simulator
     uint8_t buffer [4] = { 0, };
     SOCKET sock;
@@ -81,11 +82,11 @@ TSS2_RC SendSessionEndSocketTcti(
 
     if( tpmCmdServer )
     {
-        sock = TCTI_CONTEXT_INTEL->tpmSock;
+        sock = tcti_intel->tpmSock;
     }
     else
     {
-        sock = TCTI_CONTEXT_INTEL->otherSock;
+        sock = tcti_intel->otherSock;
     }
 
     rval = Tss2_MU_UINT32_Marshal (TPM_SESSION_END, buffer, sizeof (buffer), NULL);
@@ -103,6 +104,7 @@ TSS2_RC SocketSendTpmCommand(
     uint8_t           *command_buffer     /* in */
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     UINT32 tpmSendCommand;
     UINT32 cnt, cnt1;
     UINT8 locality;
@@ -120,12 +122,12 @@ TSS2_RC SocketSendTpmCommand(
     }
 
 #ifdef DEBUG
-    if (TCTI_CONTEXT_INTEL->status.rmDebugPrefix == 1)
+    if (tcti_intel->status.rmDebugPrefix == 1)
         rmPrefix = RM_PREFIX;
     else
         rmPrefix = NO_PREFIX;
 
-    if (TCTI_CONTEXT_INTEL->status.debugMsgEnabled == 1)
+    if (tcti_intel->status.debugMsgEnabled == 1)
     {
         TCTI_LOG( tctiContext, rmPrefix, "" );
         offset = sizeof (TPM_ST) + sizeof (UINT32);
@@ -134,7 +136,7 @@ TSS2_RC SocketSendTpmCommand(
                                  &offset,
                                  &commandCode);
 #ifdef DEBUG_SOCKETS
-        TCTI_LOG(tctiContext, NO_PREFIX, "Command sent on socket #0x%x: %s\n", TCTI_CONTEXT_INTEL->tpmSock, strTpmCommandCode(commandCode));
+        TCTI_LOG(tctiContext, NO_PREFIX, "Command sent on socket #0x%x: %s\n", tcti_intel->tpmSock, strTpmCommandCode(commandCode));
 #else
         TCTI_LOG(tctiContext, NO_PREFIX, "Cmd sent: %s\n", strTpmCommandCode(commandCode));
 #endif
@@ -150,51 +152,51 @@ TSS2_RC SocketSendTpmCommand(
                            (uint8_t*)&tpmSendCommand,
                            sizeof (tpmSendCommand),
                            NULL);  // Value for "send command" to MS simulator.
-    rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&tpmSendCommand, 4 );
+    rval = tctiSendBytes( tctiContext, tcti_intel->tpmSock, (unsigned char *)&tpmSendCommand, 4 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
 
     // Send the locality
-    locality = (UINT8)TCTI_CONTEXT_INTEL->status.locality;
-    rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&locality, 1 );
+    locality = (UINT8)tcti_intel->status.locality;
+    rval = tctiSendBytes( tctiContext, tcti_intel->tpmSock, (unsigned char *)&locality, 1 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
 
 #ifdef DEBUG
-    if (TCTI_CONTEXT_INTEL->status.debugMsgEnabled == 1)
+    if (tcti_intel->status.debugMsgEnabled == 1)
     {
-        TCTI_LOG( tctiContext, rmPrefix, "Locality = %d", TCTI_CONTEXT_INTEL->status.locality);
+        TCTI_LOG( tctiContext, rmPrefix, "Locality = %d", tcti_intel->status.locality);
     }
 #endif
 
     // Send number of bytes.
     cnt1 = cnt;
     cnt = HOST_TO_BE_32(cnt);
-    rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&cnt, 4 );
+    rval = tctiSendBytes( tctiContext, tcti_intel->tpmSock, (unsigned char *)&cnt, 4 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
 
     // Send the TPM command buffer
-    rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)command_buffer, cnt1 );
+    rval = tctiSendBytes( tctiContext, tcti_intel->tpmSock, (unsigned char *)command_buffer, cnt1 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
 
 #ifdef DEBUG
-    if (TCTI_CONTEXT_INTEL->status.debugMsgEnabled == 1)
+    if (tcti_intel->status.debugMsgEnabled == 1)
     {
         DEBUG_PRINT_BUFFER( rmPrefix, command_buffer, cnt1 );
     }
 #endif
-    TCTI_CONTEXT_INTEL->status.commandSent = 1;
+    tcti_intel->status.commandSent = 1;
 
 returnFromSocketSendTpmCommand:
 
     if( rval == TSS2_RC_SUCCESS )
     {
-        TCTI_CONTEXT_INTEL->previousStage = TCTI_STAGE_SEND_COMMAND;
-        TCTI_CONTEXT_INTEL->status.tagReceived = 0;
-        TCTI_CONTEXT_INTEL->status.responseSizeReceived = 0;
-        TCTI_CONTEXT_INTEL->status.protocolResponseSizeReceived = 0;
+        tcti_intel->previousStage = TCTI_STAGE_SEND_COMMAND;
+        tcti_intel->status.tagReceived = 0;
+        tcti_intel->status.responseSizeReceived = 0;
+        tcti_intel->status.protocolResponseSizeReceived = 0;
     }
 
     return rval;
@@ -204,13 +206,14 @@ TSS2_RC SocketCancel(
     TSS2_TCTI_CONTEXT *tctiContext
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
     if( tctiContext == 0 )
     {
         rval = TSS2_TCTI_RC_BAD_REFERENCE;
     }
-    else if (TCTI_CONTEXT_INTEL->status.commandSent != 1)
+    else if (tcti_intel->status.commandSent != 1)
     {
         rval = TSS2_TCTI_RC_BAD_SEQUENCE;
     }
@@ -227,21 +230,22 @@ TSS2_RC SocketSetLocality(
     uint8_t           locality     /* in */
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
     if( tctiContext == 0 )
     {
         rval = TSS2_TCTI_RC_BAD_REFERENCE;
     }
-    else if (TCTI_CONTEXT_INTEL->status.locality != locality)
+    else if (tcti_intel->status.locality != locality)
     {
-        if (TCTI_CONTEXT_INTEL->status.commandSent == 1)
+        if (tcti_intel->status.commandSent == 1)
         {
             rval = TSS2_TCTI_RC_BAD_SEQUENCE;
         }
         else
         {
-            TCTI_CONTEXT_INTEL->status.locality = locality;
+            tcti_intel->status.locality = locality;
         }
     }
 
@@ -260,13 +264,15 @@ void SocketFinalize(
     TSS2_TCTI_CONTEXT *tctiContext       /* in */
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
+
     if( tctiContext != NULL )
     {
         // Send session end messages to servers.
         SendSessionEndSocketTcti( tctiContext, 1 );
         SendSessionEndSocketTcti( tctiContext, 0 );
 
-        CloseSockets(TCTI_CONTEXT_INTEL->otherSock, TCTI_CONTEXT_INTEL->tpmSock);
+        CloseSockets(tcti_intel->otherSock, tcti_intel->tpmSock);
     }
 }
 
@@ -277,6 +283,7 @@ TSS2_RC SocketReceiveTpmResponse(
     int32_t         timeout
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     UINT32 trash;
     TSS2_RC rval = TSS2_RC_SUCCESS;
     fd_set readFds;
@@ -292,7 +299,7 @@ TSS2_RC SocketReceiveTpmResponse(
         goto retSocketReceiveTpmResponse;
     }
 
-    if (TCTI_CONTEXT_INTEL->status.rmDebugPrefix == 1)
+    if (tcti_intel->status.rmDebugPrefix == 1)
         rmPrefix = RM_PREFIX;
     else
         rmPrefix = NO_PREFIX;
@@ -309,12 +316,12 @@ TSS2_RC SocketReceiveTpmResponse(
     }
 
     FD_ZERO( &readFds );
-    FD_SET(TCTI_CONTEXT_INTEL->tpmSock, &readFds);
+    FD_SET(tcti_intel->tpmSock, &readFds);
 
-    iResult = select(TCTI_CONTEXT_INTEL->tpmSock + 1, &readFds, 0, 0, tvPtr);
+    iResult = select(tcti_intel->tpmSock + 1, &readFds, 0, 0, tvPtr);
     if( iResult == 0 )
     {
-        TCTI_LOG(tctiContext, rmPrefix, "select failed due to timeout, socket #: 0x%x\n", TCTI_CONTEXT_INTEL->tpmSock);
+        TCTI_LOG(tctiContext, rmPrefix, "select failed due to timeout, socket #: 0x%x\n", tcti_intel->tpmSock);
         rval = TSS2_TCTI_RC_TRY_AGAIN;
         goto retSocketReceiveTpmResponse;
     }
@@ -331,109 +338,109 @@ TSS2_RC SocketReceiveTpmResponse(
         goto retSocketReceiveTpmResponse;
     }
 
-    if (TCTI_CONTEXT_INTEL->status.protocolResponseSizeReceived != 1)
+    if (tcti_intel->status.protocolResponseSizeReceived != 1)
     {
         // Receive the size of the response.
-        rval = tctiRecvBytes(tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&TCTI_CONTEXT_INTEL->responseSize, 4);
+        rval = tctiRecvBytes(tctiContext, tcti_intel->tpmSock, (unsigned char *)&tcti_intel->responseSize, 4);
         if( rval != TSS2_RC_SUCCESS )
             goto retSocketReceiveTpmResponse;
 
-        TCTI_CONTEXT_INTEL->responseSize = BE_TO_HOST_32(TCTI_CONTEXT_INTEL->responseSize);
-        TCTI_CONTEXT_INTEL->status.protocolResponseSizeReceived = 1;
+        tcti_intel->responseSize = BE_TO_HOST_32(tcti_intel->responseSize);
+        tcti_intel->status.protocolResponseSizeReceived = 1;
     }
 
     if( response_buffer == NULL )
     {
         // In this case, just return the size
-        *response_size = TCTI_CONTEXT_INTEL->responseSize;
-        TCTI_CONTEXT_INTEL->status.protocolResponseSizeReceived = 1;
+        *response_size = tcti_intel->responseSize;
+        tcti_intel->status.protocolResponseSizeReceived = 1;
         goto retSocketReceiveTpmResponse;
     }
 
-    if (*response_size < TCTI_CONTEXT_INTEL->responseSize)
+    if (*response_size < tcti_intel->responseSize)
     {
-        *response_size = TCTI_CONTEXT_INTEL->responseSize;
+        *response_size = tcti_intel->responseSize;
         rval = TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
 
 
         // If possible, receive tag from TPM.
-        if (*response_size >= sizeof( TPM_ST ) && TCTI_CONTEXT_INTEL->status.tagReceived == 0)
+        if (*response_size >= sizeof( TPM_ST ) && tcti_intel->status.tagReceived == 0)
         {
-            if(TSS2_RC_SUCCESS != tctiRecvBytes(tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&TCTI_CONTEXT_INTEL->tag, 2))
+            if(TSS2_RC_SUCCESS != tctiRecvBytes(tctiContext, tcti_intel->tpmSock, (unsigned char *)&tcti_intel->tag, 2))
             {
                 goto retSocketReceiveTpmResponse;
             }
             else
             {
-                TCTI_CONTEXT_INTEL->status.tagReceived = 1;
+                tcti_intel->status.tagReceived = 1;
             }
         }
 
         // If possible, receive response size from TPM
-        if (*response_size >= (sizeof(TPM_ST) + sizeof(TPM_RC)) && TCTI_CONTEXT_INTEL->status.responseSizeReceived == 0)
+        if (*response_size >= (sizeof(TPM_ST) + sizeof(TPM_RC)) && tcti_intel->status.responseSizeReceived == 0)
         {
-            if(TSS2_RC_SUCCESS != tctiRecvBytes(tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&TCTI_CONTEXT_INTEL->responseSize, 4))
+            if(TSS2_RC_SUCCESS != tctiRecvBytes(tctiContext, tcti_intel->tpmSock, (unsigned char *)&tcti_intel->responseSize, 4))
             {
                 goto retSocketReceiveTpmResponse;
             }
             else
             {
-                TCTI_CONTEXT_INTEL->responseSize = BE_TO_HOST_32 (TCTI_CONTEXT_INTEL->responseSize);
-                TCTI_CONTEXT_INTEL->status.responseSizeReceived = 1;
+                tcti_intel->responseSize = BE_TO_HOST_32 (tcti_intel->responseSize);
+                tcti_intel->status.responseSizeReceived = 1;
             }
         }
     }
     else
     {
-        if (TCTI_CONTEXT_INTEL->status.debugMsgEnabled == 1 &&
-            TCTI_CONTEXT_INTEL->responseSize > 0)
+        if (tcti_intel->status.debugMsgEnabled == 1 &&
+            tcti_intel->responseSize > 0)
         {
 #ifdef DEBUG
             TCTI_LOG( tctiContext, rmPrefix, "Response Received: " );
 #endif
 #ifdef DEBUG_SOCKETS
-            TCTI_LOG(tctiContext, rmPrefix, "from socket #0x%x:\n", TCTI_CONTEXT_INTEL->tpmSock);
+            TCTI_LOG(tctiContext, rmPrefix, "from socket #0x%x:\n", tcti_intel->tpmSock);
 #endif
         }
 
-        if (TCTI_CONTEXT_INTEL->status.tagReceived == 1)
+        if (tcti_intel->status.tagReceived == 1)
         {
-            *(TPM_ST *)response_buffer = TCTI_CONTEXT_INTEL->tag;
+            *(TPM_ST *)response_buffer = tcti_intel->tag;
             responseSizeDelta += sizeof(TPM_ST);
             response_buffer += sizeof(TPM_ST);
         }
 
-        if (TCTI_CONTEXT_INTEL->status.responseSizeReceived == 1)
+        if (tcti_intel->status.responseSizeReceived == 1)
         {
-            *(TPM_RC *)response_buffer = HOST_TO_BE_32(TCTI_CONTEXT_INTEL->responseSize);
+            *(TPM_RC *)response_buffer = HOST_TO_BE_32(tcti_intel->responseSize);
             responseSizeDelta += sizeof(TPM_RC);
             response_buffer += sizeof(TPM_RC);
         }
 
         // Receive the TPM response.
-        rval = tctiRecvBytes(tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)response_buffer, TCTI_CONTEXT_INTEL->responseSize - responseSizeDelta );
+        rval = tctiRecvBytes(tctiContext, tcti_intel->tpmSock, (unsigned char *)response_buffer, tcti_intel->responseSize - responseSizeDelta );
         if( rval != TSS2_RC_SUCCESS )
             goto retSocketReceiveTpmResponse;
 
 #ifdef DEBUG
-        if (TCTI_CONTEXT_INTEL->status.debugMsgEnabled == 1)
+        if (tcti_intel->status.debugMsgEnabled == 1)
         {
-            DEBUG_PRINT_BUFFER(rmPrefix, response_buffer, TCTI_CONTEXT_INTEL->responseSize);
+            DEBUG_PRINT_BUFFER(rmPrefix, response_buffer, tcti_intel->responseSize);
         }
 #endif
 
         // Receive the appended four bytes of 0's
-        rval = tctiRecvBytes(tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&trash, 4);
+        rval = tctiRecvBytes(tctiContext, tcti_intel->tpmSock, (unsigned char *)&trash, 4);
         if( rval != TSS2_RC_SUCCESS )
             goto retSocketReceiveTpmResponse;
     }
 
-    if (TCTI_CONTEXT_INTEL->responseSize < *response_size)
+    if (tcti_intel->responseSize < *response_size)
     {
-        *response_size = TCTI_CONTEXT_INTEL->responseSize;
+        *response_size = tcti_intel->responseSize;
     }
 
-    TCTI_CONTEXT_INTEL->status.commandSent = 0;
+    tcti_intel->status.commandSent = 0;
 
     // Turn cancel off.
     if( rval == TSS2_RC_SUCCESS )
@@ -449,7 +456,7 @@ TSS2_RC SocketReceiveTpmResponse(
 retSocketReceiveTpmResponse:
     if (rval == TSS2_RC_SUCCESS && response_buffer != NULL)
     {
-        TCTI_CONTEXT_INTEL->previousStage = TCTI_STAGE_RECEIVE_RESPONSE;
+        tcti_intel->previousStage = TCTI_STAGE_RECEIVE_RESPONSE;
     }
 
     return rval;
@@ -474,18 +481,17 @@ static TSS2_RC InitializeMsTpm2Simulator(
     TSS2_TCTI_CONTEXT *tctiContext
     )
 {
-    TSS2_TCTI_CONTEXT_INTEL *intel_tctiCtx;
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     TSS2_RC rval;
 
-    intel_tctiCtx = (TSS2_TCTI_CONTEXT_INTEL*)tctiContext;
     rval = PlatformCommand( tctiContext ,MS_SIM_POWER_ON );
     if( rval != TSS2_RC_SUCCESS ) {
-        CloseSockets( intel_tctiCtx->otherSock, intel_tctiCtx->tpmSock );
+        CloseSockets( tcti_intel->otherSock, tcti_intel->tpmSock );
         return rval;
     }
     rval = PlatformCommand( tctiContext, MS_SIM_NV_ON );
     if( rval != TSS2_RC_SUCCESS )
-        CloseSockets( intel_tctiCtx->otherSock, intel_tctiCtx->tpmSock );
+        CloseSockets( tcti_intel->otherSock, tcti_intel->tpmSock );
 
     return rval;
 }
@@ -497,6 +503,7 @@ TSS2_RC InitSocketTcti (
     const uint8_t serverSockets
     )
 {
+    TSS2_TCTI_CONTEXT_INTEL *tcti_intel = tcti_context_intel_cast (tctiContext);
     TSS2_RC rval = TSS2_RC_SUCCESS;
     SOCKET otherSock;
     SOCKET tpmSock;
@@ -525,15 +532,15 @@ TSS2_RC InitSocketTcti (
         TSS2_TCTI_CANCEL( tctiContext ) = SocketCancel;
         TSS2_TCTI_GET_POLL_HANDLES( tctiContext ) = SocketGetPollHandles;
         TSS2_TCTI_SET_LOCALITY( tctiContext ) = SocketSetLocality;
-        TCTI_CONTEXT_INTEL->status.debugMsgEnabled = 0;
-        TCTI_CONTEXT_INTEL->status.locality = 3;
-        TCTI_CONTEXT_INTEL->status.commandSent = 0;
-        TCTI_CONTEXT_INTEL->status.rmDebugPrefix = 0;
-        TCTI_CONTEXT_INTEL->status.tagReceived = 0;
-        TCTI_CONTEXT_INTEL->status.responseSizeReceived = 0;
-        TCTI_CONTEXT_INTEL->status.protocolResponseSizeReceived = 0;
-        TCTI_CONTEXT_INTEL->currentTctiContext = 0;
-        TCTI_CONTEXT_INTEL->previousStage = TCTI_STAGE_INITIALIZE;
+        tcti_intel->status.debugMsgEnabled = 0;
+        tcti_intel->status.locality = 3;
+        tcti_intel->status.commandSent = 0;
+        tcti_intel->status.rmDebugPrefix = 0;
+        tcti_intel->status.tagReceived = 0;
+        tcti_intel->status.responseSizeReceived = 0;
+        tcti_intel->status.protocolResponseSizeReceived = 0;
+        tcti_intel->currentTctiContext = 0;
+        tcti_intel->previousStage = TCTI_STAGE_INITIALIZE;
         TCTI_LOG_CALLBACK( tctiContext ) = conf->logCallback;
         TCTI_LOG_BUFFER_CALLBACK( tctiContext ) = conf->logBufferCallback;
         TCTI_LOG_DATA( tctiContext ) = conf->logData;
@@ -541,8 +548,8 @@ TSS2_RC InitSocketTcti (
         rval = (TSS2_RC) InitSockets( conf->hostname, conf->port, &otherSock, &tpmSock, TCTI_LOG_CALLBACK( tctiContext ), TCTI_LOG_DATA( tctiContext) );
         if( rval == TSS2_RC_SUCCESS )
         {
-            TCTI_CONTEXT_INTEL->otherSock = otherSock;
-            TCTI_CONTEXT_INTEL->tpmSock = tpmSock;
+            tcti_intel->otherSock = otherSock;
+            tcti_intel->tpmSock = tpmSock;
             rval = InitializeMsTpm2Simulator(tctiContext);
         }
         else


### PR DESCRIPTION
…riable.

The TCTI_CONTEXT_INTEL macro was pretty unusual. It made assumptions about
the scope it was called from (variable name). These sort of things are
brittle and IMHO should be avoided. Replacing this with a macro that casts
the pointer from TSS2_TCTI_CONTEXT to a local instance of a
TSS2_TCTI_CONTEXT_INTEL pointer.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>