### PR TITLE
sysapi: fix Tss2_Sys_GetCommandCode

### DIFF
--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -75,7 +75,7 @@ typedef struct {
     // These are set by system API and used by helper functions to calculate cpHash,
     // rpHash, and for auditing.
     //
-    TPM_CC commandCodeSwapped;
+    TPM_CC commandCode;
     UINT32 cpBufferUsedSize;
     UINT8 *cpBuffer;
     UINT32 *rspParamsSize;  // Points to response paramsSize.

--- a/sysapi/sysapi/GetCommandCode.c
+++ b/sysapi/sysapi/GetCommandCode.c
@@ -31,23 +31,15 @@
 
 TSS2_RC Tss2_Sys_GetCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
-    UINT8 (*commandCode)[4]
-    )
+    UINT8 (*commandCode)[4])
 {
-    TSS2_RC rval = TSS2_RC_SUCCESS;
+    if (!sysContext || !commandCode)
+        return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if( sysContext == NULL || commandCode == NULL )
-    {
-        rval = TSS2_SYS_RC_BAD_REFERENCE;
-    }
-    else if( SYS_CONTEXT->previousStage == CMD_STAGE_INITIALIZE )
-    {
-        rval = TSS2_SYS_RC_BAD_SEQUENCE;
-    }
-    else
-    {
-        *(UINT32 *)*commandCode = BE_TO_HOST_32(SYS_CONTEXT->commandCodeSwapped);
-    }
+    if (SYS_CONTEXT->previousStage == CMD_STAGE_INITIALIZE)
+        return TSS2_SYS_RC_BAD_SEQUENCE;
 
-    return( rval );
+    *(TPM_CC *)commandCode = HOST_TO_BE_32(SYS_CONTEXT->commandCode);
+
+    return TSS2_RC_SUCCESS;
 }

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -116,8 +116,8 @@ TSS2_RC CommonPreparePrologue(
     if (rval)
         return rval;
 
+    SYS_CONTEXT->commandCode = commandCode;
     SYS_CONTEXT->numResponseHandles = GetNumResponseHandles(commandCode);
-    SYS_CONTEXT->commandCodeSwapped = HOST_TO_BE_32(commandCode);
     SYS_CONTEXT->rspParamsSize = (UINT32 *)(SYS_CONTEXT->tpmOutBuffPtr +
                                      sizeof(TPM20_Header_Out) +
                                      (GetNumResponseHandles(commandCode) * sizeof(UINT32)));

--- a/test/tpmclient/SessionHmac.c
+++ b/test/tpmclient/SessionHmac.c
@@ -59,9 +59,7 @@ UINT32 TpmComputeSessionHmac(
     TPM_RC rval;
     UINT8 nvNameChanged = 0;
     ENTITY *nvEntity;
-    UINT8 commandCode[4] = { 0, 0, 0, 0 };
-    UINT32 *cmdCodePtr;
-    UINT32 cmdCode;
+    TPM_CC cmdCode;
 
     hmacKey.b.size = 0;
 
@@ -90,7 +88,7 @@ UINT32 TpmComputeSessionHmac(
         authValue.t.size = 0;
     }
 
-    rval = Tss2_Sys_GetCommandCode( sysContext, &commandCode );
+    rval = Tss2_Sys_GetCommandCode( sysContext, (UINT8 (*)[4])&cmdCode );
     if( rval != TPM_RC_SUCCESS )
         return rval;
 
@@ -126,8 +124,6 @@ UINT32 TpmComputeSessionHmac(
     sessionAttributesByteBuffer.buffer[0] = *(UINT8 *)&sessionAttributes;
     bufferList[i++] = &( sessionAttributesByteBuffer );
     bufferList[i++] = 0;
-    cmdCodePtr = (UINT32 *)&commandCode[0];
-    cmdCode = *cmdCodePtr;
 
 #ifdef  DEBUG
     for( i = 0; bufferList[i] != 0; i++ )

--- a/test/tpmclient/TpmCalcPHash.c
+++ b/test/tpmclient/TpmCalcPHash.c
@@ -49,8 +49,7 @@ TPM_RC TpmCalcPHash( TSS2_SYS_CONTEXT *sysContext, TPM_HANDLE handle1, TPM_HANDL
     UINT8 *hashInputPtr;
     size_t parametersSize;
     const uint8_t *startParams;
-    UINT8 cmdCode[4] = {0,0,0,0};
-    UINT8 *cmdCodePtr = &cmdCode[0];
+    TPM_CC cmdCode;
 
     name1.b.size = name2.b.size = 0;
 
@@ -119,12 +118,12 @@ TPM_RC TpmCalcPHash( TSS2_SYS_CONTEXT *sysContext, TPM_HANDLE handle1, TPM_HANDL
     }
 
     // Create pHash input byte stream:  now add command code.
-    rval = Tss2_Sys_GetCommandCode( sysContext, &cmdCode );
+    rval = Tss2_Sys_GetCommandCode( sysContext, (UINT8 (*)[4])&cmdCode );
     if( rval != TPM_RC_SUCCESS )
         return rval;
 
     hashInputPtr = &( hashInput.t.buffer[hashInput.b.size] );
-    *(UINT32 *)hashInputPtr = BE_TO_HOST_32(*(UINT32 *)cmdCodePtr);
+    *(UINT32 *)hashInputPtr = cmdCode;
     hashInput.t.size += 4;
 
     // Create pHash input byte stream:  now add in names for the handles.


### PR DESCRIPTION
The spec says: [1] "This function gets the command code for the command.
The command code is returned as an array of bytes in big endian order.
This array can be used for calculating the cpHash for a command or rpHash
for a response."

The problem is that our current implementation desn't return the command
code in big endian order, although it keeps it in big endian.
What happens is it is swapped three times:

First time in CommonPreparePrologue() in CommandUtil.c, line139:
SYS_CONTEXT->commandCodeSwapped = HOST_TO_BE_32(commandCode);

Then second time in Tss2_Sys_GetCommandCode()
*(UINT32 *)*commandCode = BE_TO_HOST_32(SYS_CONTEXT->commandCodeSwapped);

And the third time in tpmclient (TpmCalcPHash.c) in TpmCalcPHash():
*(UINT32 *)hashInputPtr = BE_TO_HOST_32(*(UINT32 *)cmdCodePtr);

This wrong. We should keep it in host byte order and only swap it once
to BE in Tss2_Sys_GetCommandCode(). This is fixed in this patch.

[1]. https://trustedcomputinggroup.org/wp-content/uploads/TSS_SAPI_v1.1_r21_Public_Review.pdf