### PR TITLE
remove duplicate access ptrs from sys context struct

### DIFF
--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -58,17 +58,9 @@ typedef struct _TPM20_ErrorResponse {
 #pragma pack(pop)
 
 typedef struct {
-    //
-    // These are inputs to system API functions.
-    //
     TSS2_TCTI_CONTEXT *tctiContext;
-
-    // In and out buffers can be the same for a minimalized memory footprint implementation.
-    UINT8 *tpmInBuffPtr;            // Input: Pointer to command buffer area
-    UINT32 maxCommandSize;          // Input: max size of command buffer area
-    UINT8 *tpmOutBuffPtr;           // Input: Pointer to response buffer
-    UINT32 maxResponseSize;         // Input: max size of response buffer area
-
+    UINT8 *cmdBuffer;
+    UINT32 maxCmdSize;
     TPM20_Header_Out rsp_header;
 
     //
@@ -111,10 +103,9 @@ typedef struct {
     size_t nextData;
 } _TSS2_SYS_CONTEXT_BLOB;
 
-
 #define SYS_CONTEXT ((_TSS2_SYS_CONTEXT_BLOB *)sysContext)
-#define SYS_RESP_HEADER ((TPM20_Header_Out *)(SYS_CONTEXT->tpmOutBuffPtr))
-#define SYS_REQ_HEADER ((TPM20_Header_In *)(SYS_CONTEXT->tpmInBuffPtr))
+#define SYS_RESP_HEADER ((TPM20_Header_Out *)(SYS_CONTEXT->cmdBuffer))
+#define SYS_REQ_HEADER ((TPM20_Header_In *)(SYS_CONTEXT->cmdBuffer))
 
 typedef struct {
     TPM_CC commandCode;

--- a/sysapi/sysapi/DecryptParam.c
+++ b/sysapi/sysapi/DecryptParam.c
@@ -70,7 +70,7 @@ TSS2_RC Tss2_Sys_SetDecryptParam(
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     if (BE_TO_HOST_32(SYS_REQ_HEADER->commandSize) +
-        decryptParamSize > SYS_CONTEXT->maxCommandSize)
+        decryptParamSize > SYS_CONTEXT->maxCmdSize)
         return TSS2_SYS_RC_INSUFFICIENT_CONTEXT;
 
     rval = Tss2_Sys_GetDecryptParam(sysContext, &currDecryptParamSize,
@@ -87,7 +87,7 @@ TSS2_RC Tss2_Sys_SetDecryptParam(
         src = SYS_CONTEXT->cpBuffer + 2;
         dst = SYS_CONTEXT->cpBuffer + SYS_CONTEXT->cpBufferUsedSize + 2;
         len = SYS_CONTEXT->cpBufferUsedSize - 2;
-        limit = SYS_CONTEXT->tpmInBuffPtr + SYS_CONTEXT->maxCommandSize;
+        limit = SYS_CONTEXT->cmdBuffer + SYS_CONTEXT->maxCmdSize;
 
         if (dst + len > limit)
             return TSS2_SYS_RC_INSUFFICIENT_CONTEXT;
@@ -100,7 +100,7 @@ TSS2_RC Tss2_Sys_SetDecryptParam(
         src = decryptParamBuffer;
         dst = (UINT8 *) currDecryptParamBuffer;
         len = decryptParamSize;
-        limit = SYS_CONTEXT->tpmInBuffPtr + SYS_CONTEXT->maxCommandSize;
+        limit = SYS_CONTEXT->cmdBuffer + SYS_CONTEXT->maxCmdSize;
 
         if (dst + len > limit)
             return TSS2_SYS_RC_INSUFFICIENT_CONTEXT;
@@ -123,7 +123,7 @@ TSS2_RC Tss2_Sys_SetDecryptParam(
         src = decryptParamBuffer;
         dst = (UINT8 *) currDecryptParamBuffer;
         len = decryptParamSize;
-        limit = SYS_CONTEXT->tpmInBuffPtr + SYS_CONTEXT->maxCommandSize;
+        limit = SYS_CONTEXT->cmdBuffer + SYS_CONTEXT->maxCmdSize;
 
         if (dst + len > limit)
             return TSS2_SYS_RC_INSUFFICIENT_CONTEXT;

--- a/sysapi/sysapi/EncryptParam.c
+++ b/sysapi/sysapi/EncryptParam.c
@@ -79,7 +79,7 @@ TSS2_RC Tss2_Sys_SetEncryptParam(
         return TSS2_SYS_RC_BAD_SIZE;
 
     if (currEncryptParamBuffer + encryptParamSize >
-        SYS_CONTEXT->tpmInBuffPtr + SYS_CONTEXT->maxCommandSize)
+        SYS_CONTEXT->cmdBuffer + SYS_CONTEXT->maxCmdSize)
         return TSS2_SYS_RC_INSUFFICIENT_CONTEXT;
 
     memmove((void *)currEncryptParamBuffer,

--- a/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_ActivateCredential_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(activateHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(activateHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -59,14 +59,14 @@ TPM_RC Tss2_Sys_ActivateCredential_Prepare(
     if (!credentialBlob) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_ID_OBJECT_Marshal(credentialBlob,
-                                               SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+                                               SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     }
 
@@ -74,8 +74,8 @@ TPM_RC Tss2_Sys_ActivateCredential_Prepare(
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(secret,
-                                                  SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+                                                  SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -100,8 +100,8 @@ TPM_RC Tss2_Sys_ActivateCredential_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           certInfo);
 }

--- a/sysapi/sysapi/Tss2_Sys_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_Certify.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_Certify_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -59,20 +59,20 @@ TPM_RC Tss2_Sys_Certify_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     }
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -98,15 +98,15 @@ TPM_RC Tss2_Sys_Certify_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           certifyInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData,
                                             signature);
 }

--- a/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
+++ b/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
@@ -46,14 +46,14 @@ TPM_RC Tss2_Sys_CertifyCreation_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -61,33 +61,33 @@ TPM_RC Tss2_Sys_CertifyCreation_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval =  Tss2_MU_TPM2B_DIGEST_Marshal(creationHash, SYS_CONTEXT->tpmInBuffPtr,
-                                         SYS_CONTEXT->maxCommandSize,
+    rval =  Tss2_MU_TPM2B_DIGEST_Marshal(creationHash, SYS_CONTEXT->cmdBuffer,
+                                         SYS_CONTEXT->maxCmdSize,
                                          &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_CREATION_Marshal(creationTicket, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_TK_CREATION_Marshal(creationTicket, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -113,15 +113,15 @@ TPM_RC Tss2_Sys_CertifyCreation_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           certifyInfo);
     if (rval)
         return rval;
 
-    return rval = Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                   SYS_CONTEXT->maxCommandSize,
+    return rval = Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                   SYS_CONTEXT->maxCmdSize,
                                                    &SYS_CONTEXT->nextData,
                                                    signature);
 }

--- a/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_ChangeEPS_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_ChangePPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangePPS.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_ChangePPS_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Clear.c
+++ b/sysapi/sysapi/Tss2_Sys_Clear.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_Clear_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_ClearControl.c
+++ b/sysapi/sysapi/Tss2_Sys_ClearControl.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_ClearControl_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(disable, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(disable, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
@@ -42,13 +42,13 @@ TPM_RC Tss2_Sys_ClockRateAdjust_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(rateAdjust, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(rateAdjust, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_ClockSet.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockSet.c
@@ -42,13 +42,13 @@ TPM_RC Tss2_Sys_ClockSet_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT64_Marshal(newTime, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT64_Marshal(newTime, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Commit.c
+++ b/sysapi/sysapi/Tss2_Sys_Commit.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_Commit_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,26 +53,26 @@ TPM_RC Tss2_Sys_Commit_Prepare(
     if (!P1) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
-        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(P1, SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(P1, SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(s2, SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(s2, SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    Tss2_MU_TPM2B_ECC_PARAMETER_Marshal(y2, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    Tss2_MU_TPM2B_ECC_PARAMETER_Marshal(y2, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -100,26 +100,26 @@ TPM_RC Tss2_Sys_Commit_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData, K);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData, L);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData, E);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT16_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_UINT16_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData, counter);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ContextLoad.c
+++ b/sysapi/sysapi/Tss2_Sys_ContextLoad.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_ContextLoad_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMS_CONTEXT_Marshal(context, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMS_CONTEXT_Marshal(context, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -63,8 +63,8 @@ TPM_RC Tss2_Sys_ContextLoad_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     loadedHandle);
     if (rval)

--- a/sysapi/sysapi/Tss2_Sys_ContextSave.c
+++ b/sysapi/sysapi/Tss2_Sys_ContextSave.c
@@ -40,8 +40,8 @@ TPM_RC Tss2_Sys_ContextSave_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(saveHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(saveHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -66,8 +66,8 @@ TPM_RC Tss2_Sys_ContextSave_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_CONTEXT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMS_CONTEXT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           context);
 }

--- a/sysapi/sysapi/Tss2_Sys_Create.c
+++ b/sysapi/sysapi/Tss2_Sys_Create.c
@@ -45,8 +45,8 @@ TPM_RC Tss2_Sys_Create_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -54,35 +54,35 @@ TPM_RC Tss2_Sys_Create_Prepare(
     if (!inSensitive) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_SENSITIVE_CREATE_Marshal(inSensitive,
-                                                      SYS_CONTEXT->tpmInBuffPtr,
-                                                      SYS_CONTEXT->maxCommandSize,
+                                                      SYS_CONTEXT->cmdBuffer,
+                                                      SYS_CONTEXT->maxCmdSize,
                                                       &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(creationPCR,
-                                              SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+                                              SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -111,36 +111,36 @@ TPM_RC Tss2_Sys_Create_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData,
                                            outPrivate);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           outPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                 SYS_CONTEXT->maxCmdSize,
                                                  &SYS_CONTEXT->nextData,
                                                  creationData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           creationHash);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_CREATION_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_TK_CREATION_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           creationTicket);
 }

--- a/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
+++ b/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
@@ -48,8 +48,8 @@ TPM_RC Tss2_Sys_CreatePrimary_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(primaryHandle, SYS_CONTEXT->tpmInBuffPtr,
-                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(primaryHandle, SYS_CONTEXT->cmdBuffer,
+                          SYS_CONTEXT->maxCmdSize,
                           &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -57,34 +57,34 @@ TPM_RC Tss2_Sys_CreatePrimary_Prepare(
     if (!inSensitive) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
         rval = Tss2_MU_TPM2B_SENSITIVE_CREATE_Marshal(inSensitive,
-                                                      SYS_CONTEXT->tpmInBuffPtr,
-                                                      SYS_CONTEXT->maxCommandSize,
+                                                      SYS_CONTEXT->cmdBuffer,
+                                                      SYS_CONTEXT->maxCmdSize,
                                                       &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(creationPCR,
-                                              SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+                                              SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -111,8 +111,8 @@ TPM_RC Tss2_Sys_CreatePrimary_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmOutBuffPtr,
-                                    SYS_CONTEXT->maxResponseSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData, objectHandle);
     if (rval)
         return rval;
@@ -121,35 +121,35 @@ TPM_RC Tss2_Sys_CreatePrimary_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->tpmOutBuffPtr,
-                                          SYS_CONTEXT->maxResponseSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, outPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(SYS_CONTEXT->tpmOutBuffPtr,
-                                                 SYS_CONTEXT->maxResponseSize,
+    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                 SYS_CONTEXT->maxCmdSize,
                                                  &SYS_CONTEXT->nextData,
                                                  creationData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmOutBuffPtr,
-                                          SYS_CONTEXT->maxResponseSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           creationHash);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_CREATION_Unmarshal(SYS_CONTEXT->tpmOutBuffPtr,
-                                              SYS_CONTEXT->maxResponseSize,
+    rval = Tss2_MU_TPMT_TK_CREATION_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData,
                                               creationTicket);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->tpmOutBuffPtr,
-                                        SYS_CONTEXT->maxResponseSize,
+    rval = Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData, name);
     return rval;
 }

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(lockHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(lockHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
@@ -44,25 +44,25 @@ TPM_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(lockHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(lockHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
 
-    rval = Tss2_MU_UINT32_Marshal(newMaxTries, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(newMaxTries, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(newRecoveryTime, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(newRecoveryTime, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(lockoutRecovery, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(lockoutRecovery, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Duplicate.c
+++ b/sysapi/sysapi/Tss2_Sys_Duplicate.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_Duplicate_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(newParentHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(newParentHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -59,13 +59,13 @@ TPM_RC Tss2_Sys_Duplicate_Prepare(
     if (!encryptionKeyIn) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKeyIn, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKeyIn, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
@@ -73,8 +73,8 @@ TPM_RC Tss2_Sys_Duplicate_Prepare(
         return rval;
 
     rval = Tss2_MU_TPMT_SYM_DEF_OBJECT_Marshal(symmetricAlg,
-                                               SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+                                               SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -101,22 +101,22 @@ TPM_RC Tss2_Sys_Duplicate_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData,
                                         encryptionKeyOut);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData,
                                            duplicate);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                    SYS_CONTEXT->maxCmdSize,
                                                     &SYS_CONTEXT->nextData,
                                                     outSymSeed);
 }

--- a/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
+++ b/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_ECC_Parameters_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(curveID, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(curveID, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,8 +67,8 @@ TPM_RC Tss2_Sys_ECC_Parameters_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_ALGORITHM_DETAIL_ECC_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                       SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMS_ALGORITHM_DETAIL_ECC_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                       SYS_CONTEXT->maxCmdSize,
                                                        &SYS_CONTEXT->nextData,
                                                        parameters);
 }

--- a/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_ECDH_KeyGen_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -68,15 +68,15 @@ TPM_RC Tss2_Sys_ECDH_KeyGen_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData,
                                              zPoint);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData,
                                              pubPoint);
 }

--- a/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_ECDH_ZGen_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inPoint, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inPoint, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -74,8 +74,8 @@ TPM_RC Tss2_Sys_ECDH_ZGen_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           outPoint);
 }

--- a/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
+++ b/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_EC_Ephemeral_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(curveID, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(curveID, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,14 +67,14 @@ TPM_RC Tss2_Sys_EC_Ephemeral_Complete(
     rval = CommonComplete(sysContext);
     if (rval)
         return rval;
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData, Q);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT16_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_UINT16_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData, counter);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
@@ -45,32 +45,32 @@ TPM_RC Tss2_Sys_EncryptDecrypt_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(decrypt, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(decrypt, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(mode, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(mode, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_IV_Marshal(ivIn, SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_IV_Marshal(ivIn, SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(inData, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(inData, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -96,15 +96,15 @@ TPM_RC Tss2_Sys_EncryptDecrypt_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData,
                                               outData);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_IV_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_IV_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData,
                                       ivOut);
 }

--- a/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_EventSequenceComplete_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -81,8 +81,8 @@ TPM_RC Tss2_Sys_EventSequenceComplete_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData, results);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_EvictControl.c
+++ b/sysapi/sysapi/Tss2_Sys_EvictControl.c
@@ -41,20 +41,20 @@ TPM_RC Tss2_Sys_EvictControl_Prepare(
 
     rval = CommonPreparePrologue(sysContext, TPM_CC_EvictControl);
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(persistentHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(persistentHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
@@ -42,8 +42,8 @@ TPM_RC Tss2_Sys_FieldUpgradeData_Prepare(
         return rval;
 
     rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(fuData,
-                                            SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+                                            SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_FieldUpgradeData_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_HA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                     SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_HA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                     SYS_CONTEXT->maxCmdSize,
                                      &SYS_CONTEXT->nextData,
                                      nextDigest);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_HA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                     SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_HA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                     SYS_CONTEXT->maxCmdSize,
                                      &SYS_CONTEXT->nextData,
                                      firstDigest);
 }

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
@@ -43,14 +43,14 @@ TPM_RC Tss2_Sys_FieldUpgradeStart_Prepare(
     rval = CommonPreparePrologue(sysContext, TPM_CC_FieldUpgradeStart);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(authorization, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authorization, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -58,13 +58,13 @@ TPM_RC Tss2_Sys_FieldUpgradeStart_Prepare(
     if (!fuDigest) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(fuDigest, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(fuDigest, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
@@ -72,8 +72,8 @@ TPM_RC Tss2_Sys_FieldUpgradeStart_Prepare(
         return rval;
 
     rval = Tss2_MU_TPMT_SIGNATURE_Marshal(manifestSignature,
-                                          SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+                                          SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
+++ b/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_FirmwareRead_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceNumber, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(sequenceNumber, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,8 +67,8 @@ TPM_RC Tss2_Sys_FirmwareRead_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData, fuData);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_FlushContext.c
+++ b/sysapi/sysapi/Tss2_Sys_FlushContext.c
@@ -40,8 +40,8 @@ TPM_RC Tss2_Sys_FlushContext_Prepare(
     rval = CommonPreparePrologue(sysContext, TPM_CC_FlushContext);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(flushHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(flushHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_GetCapability.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCapability.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_GetCapability_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(capability, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(capability, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(property, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(property, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(propertyCount, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(propertyCount, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -82,15 +82,15 @@ TPM_RC Tss2_Sys_GetCapability_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                   SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                   SYS_CONTEXT->maxCmdSize,
                                    &SYS_CONTEXT->nextData,
                                    moreData);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_CAPABILITY_DATA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMS_CAPABILITY_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData,
                                                   capabilityData);
 }

--- a/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(privacyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(privacyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -59,21 +59,21 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -99,14 +99,14 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, auditInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData, signature);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_GetRandom.c
@@ -40,8 +40,8 @@ TPM_RC Tss2_Sys_GetRandom_Prepare(
     rval = CommonPreparePrologue(sysContext, TPM_CC_GetRandom);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT16_Marshal(bytesRequested, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(bytesRequested, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -66,8 +66,8 @@ TPM_RC Tss2_Sys_GetRandom_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, randomBytes);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
@@ -45,20 +45,20 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sessionHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(sessionHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -66,21 +66,21 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -106,14 +106,14 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, auditInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData, signature);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetTestResult.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTestResult.c
@@ -61,15 +61,15 @@ TPM_RC Tss2_Sys_GetTestResult_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData,
                                               outData);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     testResult);
 }

--- a/sysapi/sysapi/Tss2_Sys_GetTime.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTime.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_GetTime_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -59,20 +59,20 @@ TPM_RC Tss2_Sys_GetTime_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -98,15 +98,15 @@ TPM_RC Tss2_Sys_GetTime_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           timeInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData,
                                             signature);
 }

--- a/sysapi/sysapi/Tss2_Sys_HMAC.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_HMAC_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_HMAC_Prepare(
     if (!buffer) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -91,8 +91,8 @@ TPM_RC Tss2_Sys_HMAC_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           outHMAC);
 }

--- a/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_HMAC_Start_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,21 +53,21 @@ TPM_RC Tss2_Sys_HMAC_Start_Prepare(
     if (!auth) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -88,8 +88,8 @@ TPM_RC Tss2_Sys_HMAC_Start_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     sequenceHandle);
     if (rval)

--- a/sysapi/sysapi/Tss2_Sys_Hash.c
+++ b/sysapi/sysapi/Tss2_Sys_Hash.c
@@ -46,27 +46,27 @@ TPM_RC Tss2_Sys_Hash_Prepare(
     if (!data) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(data, SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(data, SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -92,15 +92,15 @@ TPM_RC Tss2_Sys_Hash_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           outHash);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData,
                                                validation);
 }

--- a/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
+++ b/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
@@ -45,21 +45,21 @@ TPM_RC Tss2_Sys_HashSequenceStart_Prepare(
     if (!auth) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -80,8 +80,8 @@ TPM_RC Tss2_Sys_HashSequenceStart_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     sequenceHandle);
     if (rval)

--- a/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_HierarchyControl_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(enable, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(enable, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(state, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(state, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Import.c
+++ b/sysapi/sysapi/Tss2_Sys_Import.c
@@ -46,8 +46,8 @@ TPM_RC Tss2_Sys_Import_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -55,41 +55,41 @@ TPM_RC Tss2_Sys_Import_Prepare(
     if (!encryptionKey) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKey, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKey, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Marshal(duplicate, SYS_CONTEXT->tpmInBuffPtr,
-                                         SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PRIVATE_Marshal(duplicate, SYS_CONTEXT->cmdBuffer,
+                                         SYS_CONTEXT->maxCmdSize,
                                          &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
-                                                  SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+                                                  SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPMT_SYM_DEF_OBJECT_Marshal(symmetricAlg,
-                                               SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+                                               SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -114,8 +114,8 @@ TPM_RC Tss2_Sys_Import_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData,
                                            outPrivate);
 }

--- a/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_IncrementalSelfTest_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_ALG_Marshal(toTest, SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_ALG_Marshal(toTest, SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,8 +67,8 @@ TPM_RC Tss2_Sys_IncrementalSelfTest_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_ALG_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPML_ALG_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData, toDoList);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Load.c
+++ b/sysapi/sysapi/Tss2_Sys_Load.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_Load_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_Load_Prepare(
     if (!inPrivate) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inPrivate, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inPrivate, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -88,8 +88,8 @@ TPM_RC Tss2_Sys_Load_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData, objectHandle);
     if (rval)
         return rval;
@@ -98,8 +98,8 @@ TPM_RC Tss2_Sys_Load_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData, name);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_LoadExternal.c
+++ b/sysapi/sysapi/Tss2_Sys_LoadExternal.c
@@ -45,28 +45,28 @@ TPM_RC Tss2_Sys_LoadExternal_Prepare(
     if (!inPrivate) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_SENSITIVE_Marshal(inPrivate,
-                                               SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+                                               SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-   rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->tpmInBuffPtr,
-                                       SYS_CONTEXT->maxCommandSize,
+   rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
+                                       SYS_CONTEXT->maxCmdSize,
                                        &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-   rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+   rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -88,8 +88,8 @@ TPM_RC Tss2_Sys_LoadExternal_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     objectHandle);
     if (rval)
@@ -99,8 +99,8 @@ TPM_RC Tss2_Sys_LoadExternal_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData, name);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_MakeCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_MakeCredential.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_MakeCredential_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_MakeCredential_Prepare(
     if (!credential) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(credential, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(credential, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -92,15 +92,15 @@ TPM_RC Tss2_Sys_MakeCredential_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ID_OBJECT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ID_OBJECT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData,
                                              credentialBlob);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                    SYS_CONTEXT->maxCmdSize,
                                                     &SYS_CONTEXT->nextData,
                                                     secret);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Certify.c
@@ -47,20 +47,20 @@ TPM_RC Tss2_Sys_NV_Certify_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -68,33 +68,33 @@ TPM_RC Tss2_Sys_NV_Certify_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(size, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(size, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -120,15 +120,15 @@ TPM_RC Tss2_Sys_NV_Certify_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           certifyInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData,
                                             signature);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_NV_ChangeAuth_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_NV_DefineSpace_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_NV_DefineSpace_Prepare(
     if (!auth) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NV_PUBLIC_Marshal(publicInfo, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NV_PUBLIC_Marshal(publicInfo, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Extend.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_NV_Extend_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Increment.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Increment.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_NV_Increment_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Read.c
@@ -44,26 +44,26 @@ TPM_RC Tss2_Sys_NV_Read_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(size, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(size, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -88,8 +88,8 @@ TPM_RC Tss2_Sys_NV_Read_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_MAX_NV_BUFFER_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                 SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_MAX_NV_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                 SYS_CONTEXT->maxCmdSize,
                                                  &SYS_CONTEXT->nextData,
                                                  data);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_NV_ReadLock_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_NV_ReadPublic_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -68,15 +68,15 @@ TPM_RC Tss2_Sys_NV_ReadPublic_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NV_PUBLIC_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NV_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData,
                                              nvPublic);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData,
                                         nvName);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_NV_SetBits_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT64_Marshal(bits, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT64_Marshal(bits, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_NV_UndefineSpace_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(platform, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(platform, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Write.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Write.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_NV_Write_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -59,20 +59,20 @@ TPM_RC Tss2_Sys_NV_Write_Prepare(
     if (!data) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
-        rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, SYS_CONTEXT->tpmInBuffPtr,
-                                                   SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, SYS_CONTEXT->cmdBuffer,
+                                                   SYS_CONTEXT->maxCmdSize,
                                                    &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_NV_WriteLock_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_ObjectChangeAuth_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -81,8 +81,8 @@ TPM_RC Tss2_Sys_ObjectChangeAuth_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData,
                                            outPrivate);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
@@ -42,15 +42,15 @@ TPM_RC Tss2_Sys_PCR_Allocate_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrAllocation,
-                                              SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+                                              SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -78,29 +78,29 @@ TPM_RC Tss2_Sys_PCR_Allocate_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                   SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                   SYS_CONTEXT->maxCmdSize,
                                    &SYS_CONTEXT->nextData,
                                    allocationSuccess);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     maxPCR);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     sizeNeeded);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     sizeAvailable);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_Event.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Event.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PCR_Event_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_EVENT_Marshal(eventData, SYS_CONTEXT->tpmInBuffPtr,
-                                       SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_EVENT_Marshal(eventData, SYS_CONTEXT->cmdBuffer,
+                                       SYS_CONTEXT->maxCmdSize,
                                        &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -74,8 +74,8 @@ TPM_RC Tss2_Sys_PCR_Event_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData,
                                                 digests);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PCR_Extend_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_DIGEST_VALUES_Marshal(digests, SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_DIGEST_VALUES_Marshal(digests, SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Read.c
@@ -42,8 +42,8 @@ TPM_RC Tss2_Sys_PCR_Read_Prepare(
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrSelectionIn,
-                                              SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+                                              SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -70,22 +70,22 @@ TPM_RC Tss2_Sys_PCR_Read_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     pcrUpdateCounter);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_PCR_SELECTION_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_PCR_SELECTION_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData,
                                                 pcrSelectionOut);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                         SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPML_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                         SYS_CONTEXT->maxCmdSize,
                                          &SYS_CONTEXT->nextData, pcrValues);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_PCR_Reset_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,27 +53,27 @@ TPM_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
     if (!authPolicy) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrNum, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(pcrNum, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PP_Commands.c
+++ b/sysapi/sysapi/Tss2_Sys_PP_Commands.c
@@ -43,20 +43,20 @@ TPM_RC Tss2_Sys_PP_Commands_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(setList, SYS_CONTEXT->tpmInBuffPtr,
-                                   SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_CC_Marshal(setList, SYS_CONTEXT->cmdBuffer,
+                                   SYS_CONTEXT->maxCmdSize,
                                    &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(clearList, SYS_CONTEXT->tpmInBuffPtr,
-                                   SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_CC_Marshal(clearList, SYS_CONTEXT->cmdBuffer,
+                                   SYS_CONTEXT->maxCmdSize,
                                    &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_PolicyAuthValue_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
@@ -45,8 +45,8 @@ TPM_RC Tss2_Sys_PolicyAuthorize_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -54,33 +54,33 @@ TPM_RC Tss2_Sys_PolicyAuthorize_Prepare(
     if (!approvedPolicy) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(approvedPolicy, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(approvedPolicy, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->tpmInBuffPtr,
-                                       SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
+                                       SYS_CONTEXT->maxCmdSize,
                                        &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(keySign, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NAME_Marshal(keySign, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_VERIFIED_Marshal(checkTicket, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_TK_VERIFIED_Marshal(checkTicket, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyCommandCode_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(code, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(code, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_PolicyCounterTimer_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,27 +53,27 @@ TPM_RC Tss2_Sys_PolicyCounterTimer_Prepare(
     if (!operandB) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(operation, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(operation, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyCpHash_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,27 +53,27 @@ TPM_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
     if (!objectName) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(newParentName, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NAME_Marshal(newParentName, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(includeObject, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(includeObject, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_PolicyGetDigest_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,8 +67,8 @@ TPM_RC Tss2_Sys_PolicyGetDigest_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData,
                                           policyDigest);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyLocality_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMA_LOCALITY_Marshal(locality, SYS_CONTEXT->tpmInBuffPtr,
-                                         SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMA_LOCALITY_Marshal(locality, SYS_CONTEXT->cmdBuffer,
+                                         SYS_CONTEXT->maxCmdSize,
                                          &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyNV.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNV.c
@@ -46,20 +46,20 @@ TPM_RC Tss2_Sys_PolicyNV_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,27 +67,27 @@ TPM_RC Tss2_Sys_PolicyNV_Prepare(
     if (!operandB) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(operation, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(operation, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyNvWritten_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(writtenSet, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(writtenSet, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyNameHash_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(nameHash, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(nameHash, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyOR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyOR.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyOR_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_DIGEST_Marshal(pHashList, SYS_CONTEXT->tpmInBuffPtr,
-                                       SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_DIGEST_Marshal(pHashList, SYS_CONTEXT->cmdBuffer,
+                                       SYS_CONTEXT->maxCmdSize,
                                        &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_PolicyPCR_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_PolicyPCR_Prepare(
     if (!pcrDigest) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(pcrDigest, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(pcrDigest, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrs, SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrs, SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_PolicyPassword_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_PolicyRestart_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sessionHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(sessionHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicySecret.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySecret.c
@@ -46,14 +46,14 @@ TPM_RC Tss2_Sys_PolicySecret_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -61,13 +61,13 @@ TPM_RC Tss2_Sys_PolicySecret_Prepare(
     if (!nonceTPM) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     }
 
@@ -75,29 +75,29 @@ TPM_RC Tss2_Sys_PolicySecret_Prepare(
         return rval;
 
     if (!cpHashA)
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     else
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     if (!policyRef)
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     else
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(expiration, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(expiration, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -123,14 +123,14 @@ TPM_RC Tss2_Sys_PolicySecret_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData, timeout);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, policyTicket);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicySigned.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySigned.c
@@ -47,14 +47,14 @@ TPM_RC Tss2_Sys_PolicySigned_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authObject, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authObject, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -62,39 +62,39 @@ TPM_RC Tss2_Sys_PolicySigned_Prepare(
     if (!nonceTPM) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->tpmInBuffPtr,
-                                       SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
+                                       SYS_CONTEXT->maxCmdSize,
                                        &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(expiration, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(expiration, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -120,14 +120,14 @@ TPM_RC Tss2_Sys_PolicySigned_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData, timeout);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, policyTicket);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
@@ -46,8 +46,8 @@ TPM_RC Tss2_Sys_PolicyTicket_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -55,39 +55,39 @@ TPM_RC Tss2_Sys_PolicyTicket_Prepare(
     if (!timeout) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_TIMEOUT_Marshal(timeout, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_TIMEOUT_Marshal(timeout, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->tpmInBuffPtr,
-                                       SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
+                                       SYS_CONTEXT->maxCmdSize,
                                        &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(authName, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NAME_Marshal(authName, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_AUTH_Marshal(ticket, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_TK_AUTH_Marshal(ticket, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Quote.c
+++ b/sysapi/sysapi/Tss2_Sys_Quote.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_Quote_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,27 +53,27 @@ TPM_RC Tss2_Sys_Quote_Prepare(
     if (!qualifyingData) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(PCRselect, SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(PCRselect, SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -99,14 +99,14 @@ TPM_RC Tss2_Sys_Quote_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, quoted);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData, signature);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_RSA_Decrypt_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,28 +53,28 @@ TPM_RC Tss2_Sys_RSA_Decrypt_Prepare(
     if (!cipherText) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Marshal(cipherText,
-                                                    SYS_CONTEXT->tpmInBuffPtr,
-                                                    SYS_CONTEXT->maxCommandSize,
+                                                    SYS_CONTEXT->cmdBuffer,
+                                                    SYS_CONTEXT->maxCmdSize,
                                                     &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(label, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DATA_Marshal(label, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -99,8 +99,8 @@ TPM_RC Tss2_Sys_RSA_Decrypt_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData, message);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_RSA_Encrypt_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,27 +53,27 @@ TPM_RC Tss2_Sys_RSA_Encrypt_Prepare(
     if (!message) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Marshal(message, SYS_CONTEXT->tpmInBuffPtr,
-                                                    SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Marshal(message, SYS_CONTEXT->cmdBuffer,
+                                                    SYS_CONTEXT->maxCmdSize,
                                                     &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(label, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DATA_Marshal(label, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -98,8 +98,8 @@ TPM_RC Tss2_Sys_RSA_Encrypt_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData, outData);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ReadClock.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadClock.c
@@ -60,8 +60,8 @@ TPM_RC Tss2_Sys_ReadClock_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_TIME_INFO_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMS_TIME_INFO_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData,
                                             currentTime);
 }

--- a/sysapi/sysapi/Tss2_Sys_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadPublic.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_ReadPublic_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -69,20 +69,20 @@ TPM_RC Tss2_Sys_ReadPublic_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, outPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData, name);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData, qualifiedName);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Rewrap.c
+++ b/sysapi/sysapi/Tss2_Sys_Rewrap.c
@@ -45,14 +45,14 @@ TPM_RC Tss2_Sys_Rewrap_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(oldParent, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(oldParent, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(newParent, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(newParent, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -60,28 +60,28 @@ TPM_RC Tss2_Sys_Rewrap_Prepare(
     if (!inDuplicate) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inDuplicate, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inDuplicate, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(name, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_NAME_Marshal(name, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
-                                                  SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+                                                  SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -107,14 +107,14 @@ TPM_RC Tss2_Sys_Rewrap_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData, outDuplicate);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                    SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                    SYS_CONTEXT->maxCmdSize,
                                                     &SYS_CONTEXT->nextData,
                                                     outSymSeed);
 }

--- a/sysapi/sysapi/Tss2_Sys_SelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_SelfTest.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_SelfTest_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(fullTest, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(fullTest, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
      if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_SequenceComplete_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_SequenceComplete_Prepare(
     if (!buffer) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -92,14 +92,14 @@ TPM_RC Tss2_Sys_SequenceComplete_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData, result);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData, validation);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_SequenceUpdate_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
+++ b/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_SetAlgorithmSet_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(algorithmSet, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(algorithmSet, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -44,26 +44,26 @@ TPM_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(auditAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(auditAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(setList, SYS_CONTEXT->tpmInBuffPtr,
-                                   SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_CC_Marshal(setList, SYS_CONTEXT->cmdBuffer,
+                                   SYS_CONTEXT->maxCmdSize,
                                    &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(clearList, SYS_CONTEXT->tpmInBuffPtr,
-                                   SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPML_CC_Marshal(clearList, SYS_CONTEXT->cmdBuffer,
+                                   SYS_CONTEXT->maxCmdSize,
                                    &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
     if (!authPolicy) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Shutdown.c
+++ b/sysapi/sysapi/Tss2_Sys_Shutdown.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_Shutdown_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(shutdownType, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(shutdownType, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Sign.c
+++ b/sysapi/sysapi/Tss2_Sys_Sign.c
@@ -44,8 +44,8 @@ TPM_RC Tss2_Sys_Sign_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -53,27 +53,27 @@ TPM_RC Tss2_Sys_Sign_Prepare(
     if (!digest) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_HASHCHECK_Marshal(validation, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_TK_HASHCHECK_Marshal(validation, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -98,8 +98,8 @@ TPM_RC Tss2_Sys_Sign_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData, signature);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_StartAuthSession.c
+++ b/sysapi/sysapi/Tss2_Sys_StartAuthSession.c
@@ -47,14 +47,14 @@ TPM_RC Tss2_Sys_StartAuthSession_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(tpmKey, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(tpmKey, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(bind, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(bind, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -62,13 +62,13 @@ TPM_RC Tss2_Sys_StartAuthSession_Prepare(
     if (!nonceCaller) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceCaller, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceCaller, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     }
 
@@ -76,26 +76,26 @@ TPM_RC Tss2_Sys_StartAuthSession_Prepare(
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(encryptedSalt,
-                                                  SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+                                                  SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(sessionType, SYS_CONTEXT->tpmInBuffPtr,
-                                 SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT8_Marshal(sessionType, SYS_CONTEXT->cmdBuffer,
+                                 SYS_CONTEXT->maxCmdSize,
                                  &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SYM_DEF_Marshal(symmetric, SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SYM_DEF_Marshal(symmetric, SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(authHash, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(authHash, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -117,8 +117,8 @@ TPM_RC Tss2_Sys_StartAuthSession_Complete(
     if (!sysContext)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                    SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                    SYS_CONTEXT->maxCmdSize,
                                     &SYS_CONTEXT->nextData,
                                     sessionHandle);
     if (rval)
@@ -128,8 +128,8 @@ TPM_RC Tss2_Sys_StartAuthSession_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NONCE_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                         SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_NONCE_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                         SYS_CONTEXT->maxCmdSize,
                                          &SYS_CONTEXT->nextData, nonceTPM);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Startup.c
+++ b/sysapi/sysapi/Tss2_Sys_Startup.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_Startup_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(startupType, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(startupType, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_StirRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_StirRandom.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_StirRandom_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(inData, SYS_CONTEXT->tpmInBuffPtr,
-                                                SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(inData, SYS_CONTEXT->cmdBuffer,
+                                                SYS_CONTEXT->maxCmdSize,
                                                 &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_TestParms.c
+++ b/sysapi/sysapi/Tss2_Sys_TestParms.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_TestParms_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_PUBLIC_PARMS_Marshal(parameters, SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_PUBLIC_PARMS_Marshal(parameters, SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData);
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_Unseal.c
+++ b/sysapi/sysapi/Tss2_Sys_Unseal.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_Unseal_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(itemHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(itemHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,8 +67,8 @@ TPM_RC Tss2_Sys_Unseal_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_SENSITIVE_DATA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                                  SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_SENSITIVE_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                                  SYS_CONTEXT->maxCmdSize,
                                                   &SYS_CONTEXT->nextData,
                                                   outData);
 }

--- a/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
+++ b/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
@@ -41,8 +41,8 @@ TPM_RC Tss2_Sys_Vendor_TCG_Test_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(inputData, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_DATA_Marshal(inputData, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -67,8 +67,8 @@ TPM_RC Tss2_Sys_Vendor_TCG_Test_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DATA_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                        SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                        SYS_CONTEXT->maxCmdSize,
                                         &SYS_CONTEXT->nextData, outputData);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_VerifySignature.c
+++ b/sysapi/sysapi/Tss2_Sys_VerifySignature.c
@@ -43,8 +43,8 @@ TPM_RC Tss2_Sys_VerifySignature_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -52,21 +52,21 @@ TPM_RC Tss2_Sys_VerifySignature_Prepare(
     if (!digest) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, SYS_CONTEXT->tpmInBuffPtr,
-                                            SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, SYS_CONTEXT->cmdBuffer,
+                                            SYS_CONTEXT->maxCmdSize,
                                             &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(signature, SYS_CONTEXT->tpmInBuffPtr,
-                                          SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(signature, SYS_CONTEXT->cmdBuffer,
+                                          SYS_CONTEXT->maxCmdSize,
                                           &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -91,8 +91,8 @@ TPM_RC Tss2_Sys_VerifySignature_Complete(
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_VERIFIED_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                              SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPMT_TK_VERIFIED_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                              SYS_CONTEXT->maxCmdSize,
                                               &SYS_CONTEXT->nextData, validation);
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
+++ b/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
@@ -45,8 +45,8 @@ TPM_RC Tss2_Sys_ZGen_2Phase_Prepare(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyA, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT32_Marshal(keyA, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -54,33 +54,33 @@ TPM_RC Tss2_Sys_ZGen_2Phase_Prepare(
     if (!inQsB) {
         SYS_CONTEXT->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->tpmInBuffPtr,
-                                      SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
+                                      SYS_CONTEXT->maxCmdSize,
                                       &SYS_CONTEXT->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQsB, SYS_CONTEXT->tpmInBuffPtr,
-                                               SYS_CONTEXT->maxCommandSize,
+        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQsB, SYS_CONTEXT->cmdBuffer,
+                                               SYS_CONTEXT->maxCmdSize,
                                                &SYS_CONTEXT->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQeB, SYS_CONTEXT->tpmInBuffPtr,
-                                           SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQeB, SYS_CONTEXT->cmdBuffer,
+                                           SYS_CONTEXT->maxCmdSize,
                                            &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(inScheme, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(counter, SYS_CONTEXT->tpmInBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_UINT16_Marshal(counter, SYS_CONTEXT->cmdBuffer,
+                                  SYS_CONTEXT->maxCmdSize,
                                   &SYS_CONTEXT->nextData);
     if (rval)
         return rval;
@@ -106,14 +106,14 @@ TPM_RC Tss2_Sys_ZGen_2Phase_Complete(
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData, outZ1);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->tpmInBuffPtr,
-                                             SYS_CONTEXT->maxCommandSize,
+    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
+                                             SYS_CONTEXT->maxCmdSize,
                                              &SYS_CONTEXT->nextData, outZ2);
 }
 

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -5224,7 +5224,7 @@ void GetSetDecryptParamTests()
     rval = Tss2_Sys_GetCpBuffer( decryptParamTestSysContext, &cpBufferUsedSize2, &cpBuffer2 );
     CheckPassed( rval );
     nvWriteData.t.size = MAX_NV_BUFFER_SIZE -
-            BE_TO_HOST_32(((TPM20_Header_In *)(((_TSS2_SYS_CONTEXT_BLOB *)decryptParamTestSysContext)->tpmInBuffPtr))->commandSize) + 1;
+            BE_TO_HOST_32(((TPM20_Header_In *)(((_TSS2_SYS_CONTEXT_BLOB *)decryptParamTestSysContext)->cmdBuffer))->commandSize) + 1;
 
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, nvWriteData.t.size, &( nvWriteData.t.buffer[0] ) );
     CheckFailed( rval, TSS2_SYS_RC_INSUFFICIENT_CONTEXT );
@@ -5534,36 +5534,36 @@ void CmdRspAuthsTests()
 
     // Test for insufficient context.
     cmdAuths.cmdAuthsCount= 0;
-    savedMaxCommandSize = ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize;
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE ) - 1;
+    savedMaxCommandSize = ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize;
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE ) - 1;
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval ); // #12
 
     cmdAuths.cmdAuthsCount= 0;
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE );
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE );
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval );// #13
 
     cmdAuths.cmdAuthsCount= 3;
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE );
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE );
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckFailed( rval, TSS2_SYS_RC_INSUFFICIENT_CONTEXT ); // #14
 
     // Do successful one; use this to get size of command.
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = savedMaxCommandSize;
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = savedMaxCommandSize;
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval ); // #15
 
-    // Then set maxCommandSize to the the previously gotten commandSize - 1.  This should fail.
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = GetCommandSize( sysContext ) - 1;
+    // Then set maxCmdSize to the the previously gotten commandSize - 1.  This should fail.
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = GetCommandSize( sysContext ) - 1;
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckFailed( rval, TSS2_SYS_RC_INSUFFICIENT_CONTEXT ); // #16
 
     // Reset size of sysContext.
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = savedMaxCommandSize;
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = savedMaxCommandSize;
 
     // Setup for response auths test.
-    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = BE_TO_HOST_32( savedMaxCommandSize );
+    ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCmdSize = BE_TO_HOST_32( savedMaxCommandSize );
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval ); // #15
 

--- a/test/unit/CopyCommandHeader.c
+++ b/test/unit/CopyCommandHeader.c
@@ -26,7 +26,7 @@ CopyCommandHeader_sys_setup (void **state)
      *  the command buffer in the memory pointed to by tpmInitBuffPtr. This
      *  must point to the data after the context structure.
      */
-    sys_ctx->tpmInBuffPtr = (UINT8*) (sys_ctx + sizeof (_TSS2_SYS_CONTEXT_BLOB));
+    sys_ctx->cmdBuffer = (UINT8*) (sys_ctx + sizeof (_TSS2_SYS_CONTEXT_BLOB));
     InitSysContextFields ((TSS2_SYS_CONTEXT*)sys_ctx);
     InitSysContextPtrs ((TSS2_SYS_CONTEXT*)sys_ctx, size_ctx);
 
@@ -63,7 +63,7 @@ CopyCommandHeader_nextData_unit (void **state)
 
 /**
  * After a call to CopyCommandHeader the tag in the TPM20_Header_In portion of
- * the tpmInBuffPtr member of the sys context should be TPM_ST_NO_SESSIONS
+ * the cmdBuffer member of the sys context should be TPM_ST_NO_SESSIONS
  * transformed into network byte order.
  */
 static void
@@ -71,7 +71,7 @@ CopyCommandHeader_tag_unit (void **state)
 {
     _TSS2_SYS_CONTEXT_BLOB *sys_ctx = (_TSS2_SYS_CONTEXT_BLOB*)*state;
     TPM_CC cc = TPM_CC_GetCapability;
-    TPM20_Header_In *header = (TPM20_Header_In*)sys_ctx->tpmInBuffPtr;
+    TPM20_Header_In *header = (TPM20_Header_In*)sys_ctx->cmdBuffer;
     /* The TSS code uses a custom function to convert stuff to network byte
      * order but we can just use htons. Not sure why we don't use htons/l
      * everywhere.
@@ -83,7 +83,7 @@ CopyCommandHeader_tag_unit (void **state)
 }
 /**
  * After a call to CopyCommandHeader the commandCode in the TPM20_Header_In
- * portion of the tpmInBuffPtr member of the sys context should be the command
+ * portion of the cmdBuffer member of the sys context should be the command
  * code parameter in network byte order.
  */
 static void
@@ -92,7 +92,7 @@ CopyCommandHeader_commandcode_unit (void **state)
     _TSS2_SYS_CONTEXT_BLOB *sys_ctx = (_TSS2_SYS_CONTEXT_BLOB*)*state;
     TPM_CC cc = TPM_CC_GetCapability;
     TPM_CC cc_net = htonl (cc);
-    TPM20_Header_In *header = (TPM20_Header_In*)sys_ctx->tpmInBuffPtr;
+    TPM20_Header_In *header = (TPM20_Header_In*)sys_ctx->cmdBuffer;
 
     CopyCommandHeader ((TSS2_SYS_CONTEXT*)sys_ctx, cc);
     assert_int_equal (cc_net, header->commandCode);


### PR DESCRIPTION
The context command/response buffer is accessed by
SYS_CONTEXT->tpmInBuffPtr/SYS_CONTEXT->maxCommandSize
SYS_CONTEXT->tpmOutBuffPtr/SYS_CONTEXT->maxResponseSize
pointers/limiters for tpm commands and tpm responses respectively.
Even though they are separate, they point to the same buffer
and have the same size values always. They are also used quite loosely,
and the tpmInBuffPtr seems to be used most of the times to
access both commands and responses.
This patch replaces them with a single pairtpm commands and
SYS_CONTEXT->cmdBuffer/SYS_CONTEXT->maxCmdSize to handle both
tpm commands and tpm responses.

Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>