### PR TITLE
tss2_tpm2_types.h: fix the typos in the definition of HMAC_SESSION_LA…

### DIFF
--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -433,11 +433,11 @@ typedef	TPM_HANDLE TPM_HC;
 #define	PCR_FIRST	(HR_PCR + 0 )	 /* first PCR  */
 #define	PCR_LAST	(PCR_FIRST + IMPLEMENTATION_PCR - 1 )	 /* last PCR  */
 #define	HMAC_SESSION_FIRST	(HR_HMAC_SESSION + 0 )	 /* first HMAC session  */
-#define	HMAC_SESSION_LAST	(HMAC_SESSION_FIRST+MAX_ACTIVE_SESSIONS1 )	 /* last HMAC session  */
+#define	HMAC_SESSION_LAST	(HMAC_SESSION_FIRST + MAX_ACTIVE_SESSIONS - 1 )	 /* last HMAC session  */
 #define	LOADED_SESSION_FIRST	(HMAC_SESSION_FIRST )	 /* used in GetCapability  */
 #define	LOADED_SESSION_LAST	(HMAC_SESSION_LAST )	 /* used in GetCapability  */
 #define	POLICY_SESSION_FIRST	(HR_POLICY_SESSION + 0 )	 /* first policy session  */
-#define	POLICY_SESSION_LAST	(POLICY_SESSION_FIRST + MAX_ACTIVE_SESSIONS1 )	 /* last policy session   */
+#define	POLICY_SESSION_LAST	(POLICY_SESSION_FIRST + MAX_ACTIVE_SESSIONS - 1 )	 /* last policy session   */
 #define	TRANSIENT_FIRST	(HR_TRANSIENT + 0 )	 /* first transient object  */
 #define	ACTIVE_SESSION_FIRST	(POLICY_SESSION_FIRST )	 /* used in GetCapability  */
 #define	ACTIVE_SESSION_LAST	(POLICY_SESSION_LAST )	 /* used in GetCapability  */


### PR DESCRIPTION
…ST and POLICY_SESSION_LAST

Obviously the macro MAX_ACTIVE_SESSIONS1 is undefined and meaningless.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>